### PR TITLE
move cp of artifact from jenkinsfile to gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ bin
 *.env
 gradle.properties
 /.gradle/
+/docker/app*.jar*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,5 @@ def stageBuild(def context) {
     withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_USERNAME=${context.nexusUsername}", "NEXUS_PASSWORD=${context.nexusPassword}", "NEXUS_HOST=${context.nexusHost}", "JAVA_OPTS=${javaOpts}","GRADLE_TEST_OPTS=${gradleTestOpts}","ENVIRONMENT=${springBootEnv}"]) {
       sh "./gradlew clean build --stacktrace --no-daemon"
     }
-    sh "cp build/libs/${context.componentId}-*.jar docker/app.jar"
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,8 @@ uploadArchives {
 }
 
 jar {
-    archiveName  "prov-app-${version}-${classifier}.${extension}"
+    archiveName     "app.jar"
+	destinationDir  file("$buildDir/../docker")
 }
 
 jacoco {


### PR DESCRIPTION
opendevstack/ods-project-quickstarters/#41 

Idea is to be able to run

- gradle build
- docker build & run locally w/o modification of an artifact