### PR TITLE
Add production pipeline

### DIFF
--- a/ocp-config/prov-cd/bc.yml
+++ b/ocp-config/prov-cd/bc.yml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Template
+objects:
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    labels:
+      app: jenkins
+    name: ods-provisioning-app-production
+  spec:
+    nodeSelector: {}
+    output: {}
+    postCommit: {}
+    resources: {}
+    runPolicy: Serial
+    source:
+      git:
+        ref: production
+        uri: ${REPO_BASE}/opendevstack/ods-provisioning-app.git
+      sourceSecret:
+        name: cd-user-with-password
+      type: Git
+    strategy:
+      jenkinsPipelineStrategy:
+        jenkinsfilePath: Jenkinsfile
+      type: JenkinsPipeline
+    triggers:
+    - generic:
+        secret: ${PIPELINE_TRIGGER_SECRET}
+      type: Generic
+parameters:
+- name: REPO_BASE
+  required: true
+- name: PIPELINE_TRIGGER_SECRET
+  required: true


### PR DESCRIPTION
That way, the user already has a production Jenkins pipeline which can
be triggered easily. It is likely that many users will not make any
commits in the provisioning app repo, and therefore not pipeline will be
created.

Closes #68.