### PR TITLE
fix #160 MailConnectException/healthcheck when mail configuration is …

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -126,3 +126,5 @@ spring.mail.smtps.connectiontimeout=1000
 
 provison.mail.sender=provision@opendevstack.org
 spring.main.allow-bean-definition-overriding=true
+
+management.health.mail.enabled=${mail.enabled}


### PR DESCRIPTION
…invalid even if mail is disabled in configuration (disable/enable mail server health check if mail is disabled/enabled)