### PR TITLE
Bugfix application logs invalid number of existing projects, because …

### DIFF
--- a/src/main/java/org/opendevstack/provision/controller/ProjectApiController.java
+++ b/src/main/java/org/opendevstack/provision/controller/ProjectApiController.java
@@ -245,6 +245,8 @@ public class ProjectApiController {
       // add the scm url & bugtracker space bool
       updatedProject.scmvcsUrl = storedExistingProject.scmvcsUrl;
       updatedProject.bugtrackerSpace = storedExistingProject.bugtrackerSpace;
+      updatedProject.repositories = storedExistingProject.repositories;
+
       // we purposely allow overwriting platformRuntime settings, to create a project later
       // on
       if (!storedExistingProject.platformRuntime


### PR DESCRIPTION
…variable 'updatedProject' was not completely initialized