### PR TITLE
Naming conventions for quickstarters

### DIFF
--- a/src/main/java/org/opendevstack/provision/config/AppConfig.java
+++ b/src/main/java/org/opendevstack/provision/config/AppConfig.java
@@ -14,15 +14,20 @@
 
 package org.opendevstack.provision.config;
 
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import org.opendevstack.provision.util.rules.ComponentNamingRules;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.thymeleaf.extras.springsecurity5.dialect.SpringSecurityDialect;
 import org.thymeleaf.spring5.SpringTemplateEngine;
 import org.thymeleaf.templateresolver.ITemplateResolver;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
 
 /**
  * Represents basic bean configurations not related to security
@@ -46,5 +51,18 @@ public class AppConfig {
   @Bean(name = "projectKeys")
   public List<String> globalProjectKeys() {
     return new ArrayList<>(Arrays.asList(projectTemplateKeyNames));
+  }
+
+  @Bean(name = "quickstartersNamingRules")
+  public List<ComponentNamingRules> componentNamingRules() {
+    Yaml yaml = new Yaml(new Constructor(ComponentNamingRules.class));
+    InputStream inputStream = this.getClass()
+            .getClassLoader()
+            .getResourceAsStream("quickstarter-naming-rules.yml");
+    List<ComponentNamingRules> rules = new ArrayList<>();
+    for (Object o: yaml.loadAll(inputStream)) {
+      rules.add((ComponentNamingRules) o);
+    }
+    return rules;
   }
 }

--- a/src/main/java/org/opendevstack/provision/config/AppConfig.java
+++ b/src/main/java/org/opendevstack/provision/config/AppConfig.java
@@ -18,7 +18,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import org.opendevstack.provision.util.rules.ComponentNamingRules;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -56,11 +55,10 @@ public class AppConfig {
   @Bean(name = "quickstartersNamingRules")
   public List<ComponentNamingRules> componentNamingRules() {
     Yaml yaml = new Yaml(new Constructor(ComponentNamingRules.class));
-    InputStream inputStream = this.getClass()
-            .getClassLoader()
-            .getResourceAsStream("quickstarter-naming-rules.yml");
+    InputStream inputStream =
+        this.getClass().getClassLoader().getResourceAsStream("quickstarter-naming-rules.yml");
     List<ComponentNamingRules> rules = new ArrayList<>();
-    for (Object o: yaml.loadAll(inputStream)) {
+    for (Object o : yaml.loadAll(inputStream)) {
       rules.add((ComponentNamingRules) o);
     }
     return rules;

--- a/src/main/java/org/opendevstack/provision/controller/ProjectApiController.java
+++ b/src/main/java/org/opendevstack/provision/controller/ProjectApiController.java
@@ -115,7 +115,9 @@ public class ProjectApiController {
     }
 
     // check correctness of a project quickstarters naming, and discard wrongly named
-    newProject.quickstarters = filterQuickstarters(newProject.quickstarters);
+    if (newProject.quickstarters != null) {
+      newProject.quickstarters = filterQuickstarters(newProject.quickstarters);
+    }
 
     if (newProject.specialPermissionSet && !jiraAdapter.isSpecialPermissionSchemeEnabled()) {
       return ResponseEntity.badRequest()
@@ -233,7 +235,7 @@ public class ProjectApiController {
       // Find right name for a component
       for(Job job: availableQuickstarters) {
         if(job.getId().equals(component_type)) {
-          component_name = job.getId();
+          component_name = job.getName();
           break;
         }
       }
@@ -300,7 +302,9 @@ public class ProjectApiController {
       updatedProject.projectName = storedExistingProject.projectName;
 
       // check correctness of a project quickstarters naming, and discard wrongly named
-      updatedProject.quickstarters = filterQuickstarters(updatedProject.quickstarters);
+      if (updatedProject.quickstarters != null) {
+        updatedProject.quickstarters = filterQuickstarters(updatedProject.quickstarters);
+      }
 
       // add the scm url & bugtracker space bool
       updatedProject.scmvcsUrl = storedExistingProject.scmvcsUrl;

--- a/src/main/java/org/opendevstack/provision/controller/ProjectApiController.java
+++ b/src/main/java/org/opendevstack/provision/controller/ProjectApiController.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import org.opendevstack.provision.adapter.IBugtrackerAdapter;
 import org.opendevstack.provision.adapter.ICollaborationAdapter;
 import org.opendevstack.provision.adapter.IJobExecutionAdapter;
@@ -221,20 +220,21 @@ public class ProjectApiController {
   private List<Map<String, String>> filterQuickstarters(List<Map<String, String>> quickstarters) {
     /**
      * Pushes every quckstarter object though chain of filters.
+     *
      * @param quickstarters - selected by user quickstarters to create
      * @return list of correctly named parameters
      */
     List<Job> availableQuickstarters = rundeckAdapter.getQuickstarters();
     List<Map<String, String>> filteredQuickstarters = new ArrayList<>();
 
-    for(Map<String, String> quickstarter_option : quickstarters) {
+    for (Map<String, String> quickstarter_option : quickstarters) {
       String component_id = quickstarter_option.get(OpenProjectData.COMPONENT_ID_KEY);
       String component_type = quickstarter_option.get(OpenProjectData.COMPONENT_TYPE_KEY);
       // Get quickstarter name
       String component_name = "";
       // Find right name for a component
-      for(Job job: availableQuickstarters) {
-        if(job.getId().equals(component_type)) {
+      for (Job job : availableQuickstarters) {
+        if (job.getId().equals(component_type)) {
           component_name = job.getName();
           break;
         }
@@ -248,22 +248,23 @@ public class ProjectApiController {
     return filteredQuickstarters;
   }
 
-
-
   private boolean isNamingComponentTypeCorrect(String component_name, String component_id) {
     /**
      * Checks if component to be created has been named properly.
-     *  @param component_name: component (quickstarter) name in the Provision application DB
-     *  @param component_id: user input name for a quickstarter generated component
-     *  @return boolean value
+     *
+     * @param component_name: component (quickstarter) name in the Provision application DB
+     * @param component_id: user input name for a quickstarter generated component
+     * @return boolean value
      */
-    List<ComponentNamingRules> namingRules = this.quickstartersNamingRules.stream()
+    List<ComponentNamingRules> namingRules =
+        this.quickstartersNamingRules.stream()
             .filter((r) -> r.getName().equals(component_name))
             .collect(Collectors.toList());
-    for(ComponentNamingRules rules: namingRules) {
-      if(!rules.filter(component_id)) {
+    for (ComponentNamingRules rules : namingRules) {
+      if (!rules.filter(component_id)) {
         return false;
-      };
+      }
+      ;
     }
     return true;
   }

--- a/src/main/java/org/opendevstack/provision/controller/QuickstarterApiController.java
+++ b/src/main/java/org/opendevstack/provision/controller/QuickstarterApiController.java
@@ -20,6 +20,7 @@ import org.opendevstack.provision.adapter.IJobExecutionAdapter;
 import org.opendevstack.provision.model.ExecutionsData;
 import org.opendevstack.provision.model.ProjectData;
 import org.opendevstack.provision.model.rundeck.Job;
+import org.opendevstack.provision.util.rules.ComponentNamingRules;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,6 +38,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class QuickstarterApiController {
 
   @Autowired private IJobExecutionAdapter rundeckAdapter;
+  @Autowired private List<ComponentNamingRules> quickstartersNamingRules;
 
   /**
    * Call to get the available quickstarters
@@ -60,5 +62,13 @@ public class QuickstarterApiController {
         rundeckAdapter.provisionComponentsBasedOnQuickstarters(
             ProjectData.toOpenProjectData(project));
     return ResponseEntity.ok(executions);
+  }
+
+  @RequestMapping(
+          value = "/rules",
+          produces = {"application/json"},
+          method = RequestMethod.GET)
+  public ResponseEntity<List<ComponentNamingRules>> getQuickstartersNamingRules() {
+    return ResponseEntity.ok().body(quickstartersNamingRules);
   }
 }

--- a/src/main/java/org/opendevstack/provision/controller/QuickstarterApiController.java
+++ b/src/main/java/org/opendevstack/provision/controller/QuickstarterApiController.java
@@ -65,9 +65,9 @@ public class QuickstarterApiController {
   }
 
   @RequestMapping(
-          value = "/rules",
-          produces = {"application/json"},
-          method = RequestMethod.GET)
+      value = "/rules",
+      produces = {"application/json"},
+      method = RequestMethod.GET)
   public ResponseEntity<List<ComponentNamingRules>> getQuickstartersNamingRules() {
     return ResponseEntity.ok().body(quickstartersNamingRules);
   }

--- a/src/main/java/org/opendevstack/provision/util/rules/ComponentNamingRules.java
+++ b/src/main/java/org/opendevstack/provision/util/rules/ComponentNamingRules.java
@@ -1,0 +1,30 @@
+package org.opendevstack.provision.util.rules;
+
+import java.util.List;
+
+public class ComponentNamingRules {
+    private String name;
+    private List<NamingRule> rules;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<NamingRule> getRules() {
+        return rules;
+    }
+
+    public void setRules(List<NamingRule> rules) {
+        this.rules = rules;
+    }
+
+    public boolean filter(String componentName) {
+        return !this.rules.stream()
+                .map((namingRule -> namingRule.filter(componentName)))
+                .anyMatch((res) -> res == false);
+    }
+}

--- a/src/main/java/org/opendevstack/provision/util/rules/ComponentNamingRules.java
+++ b/src/main/java/org/opendevstack/provision/util/rules/ComponentNamingRules.java
@@ -7,24 +7,24 @@ public class ComponentNamingRules {
   private List<NamingRule> rules;
 
   public String getName() {
-        return name;
-    }
+    return name;
+  }
 
   public void setName(String name) {
-        this.name = name;
-    }
+    this.name = name;
+  }
 
   public List<NamingRule> getRules() {
-        return rules;
-    }
+    return rules;
+  }
 
   public void setRules(List<NamingRule> rules) {
-        this.rules = rules;
-    }
+    this.rules = rules;
+  }
 
   public boolean filter(String componentName) {
-      return !this.rules.stream()
-              .map((namingRule -> namingRule.filter(componentName)))
-              .anyMatch((res) -> res == false);
+    return !this.rules.stream()
+        .map((namingRule -> namingRule.filter(componentName)))
+        .anyMatch((res) -> res == false);
   }
 }

--- a/src/main/java/org/opendevstack/provision/util/rules/ComponentNamingRules.java
+++ b/src/main/java/org/opendevstack/provision/util/rules/ComponentNamingRules.java
@@ -3,28 +3,28 @@ package org.opendevstack.provision.util.rules;
 import java.util.List;
 
 public class ComponentNamingRules {
-    private String name;
-    private List<NamingRule> rules;
+  private String name;
+  private List<NamingRule> rules;
 
-    public String getName() {
+  public String getName() {
         return name;
     }
 
-    public void setName(String name) {
+  public void setName(String name) {
         this.name = name;
     }
 
-    public List<NamingRule> getRules() {
+  public List<NamingRule> getRules() {
         return rules;
     }
 
-    public void setRules(List<NamingRule> rules) {
+  public void setRules(List<NamingRule> rules) {
         this.rules = rules;
     }
 
-    public boolean filter(String componentName) {
-        return !this.rules.stream()
-                .map((namingRule -> namingRule.filter(componentName)))
-                .anyMatch((res) -> res == false);
-    }
+  public boolean filter(String componentName) {
+      return !this.rules.stream()
+              .map((namingRule -> namingRule.filter(componentName)))
+              .anyMatch((res) -> res == false);
+  }
 }

--- a/src/main/java/org/opendevstack/provision/util/rules/NamingRule.java
+++ b/src/main/java/org/opendevstack/provision/util/rules/NamingRule.java
@@ -4,46 +4,46 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class NamingRule {
-    String reg;
-    Boolean not;
-    String description;
-    String errorMessage;
+  String reg;
+  Boolean not;
+  String description;
+  String errorMessage;
 
-    public String getReg() {
+  public String getReg() {
         return reg;
     }
 
-    public void setReg(String reg) {
+  public void setReg(String reg) {
         this.reg = reg;
     }
 
-    public Boolean getNot() {
+  public Boolean getNot() {
         return not;
     }
 
-    public void setNot(Boolean not) {
+  public void setNot(Boolean not) {
         this.not = not;
     }
 
-    public String getDescription() {
+  public String getDescription() {
         return description;
     }
 
-    public void setDescription(String description) {
+  public void setDescription(String description) {
         this.description = description;
     }
 
-    public String getErrorMessage() {
+  public String getErrorMessage() {
         return errorMessage;
     }
 
-    public void setErrorMessage(String errorMessage) {
+  public void setErrorMessage(String errorMessage) {
         this.errorMessage = errorMessage;
     }
 
-    public boolean filter(String name) {
-        Matcher m = Pattern.compile(this.reg)
-                .matcher(name);
-        return  this.not ? !m.find() : m.find();
-    }
+  public boolean filter(String name) {
+      Matcher m = Pattern.compile(this.reg)
+              .matcher(name);
+      return  this.not ? !m.find() : m.find();
+  }
 }

--- a/src/main/java/org/opendevstack/provision/util/rules/NamingRule.java
+++ b/src/main/java/org/opendevstack/provision/util/rules/NamingRule.java
@@ -10,40 +10,39 @@ public class NamingRule {
   String errorMessage;
 
   public String getReg() {
-        return reg;
-    }
+    return reg;
+  }
 
   public void setReg(String reg) {
-        this.reg = reg;
-    }
+    this.reg = reg;
+  }
 
   public Boolean getNot() {
-        return not;
-    }
+    return not;
+  }
 
   public void setNot(Boolean not) {
-        this.not = not;
-    }
+    this.not = not;
+  }
 
   public String getDescription() {
-        return description;
-    }
+    return description;
+  }
 
   public void setDescription(String description) {
-        this.description = description;
-    }
+    this.description = description;
+  }
 
   public String getErrorMessage() {
-        return errorMessage;
-    }
+    return errorMessage;
+  }
 
   public void setErrorMessage(String errorMessage) {
-        this.errorMessage = errorMessage;
-    }
+    this.errorMessage = errorMessage;
+  }
 
   public boolean filter(String name) {
-      Matcher m = Pattern.compile(this.reg)
-              .matcher(name);
-      return  this.not ? !m.find() : m.find();
+    Matcher m = Pattern.compile(this.reg).matcher(name);
+    return this.not ? !m.find() : m.find();
   }
 }

--- a/src/main/java/org/opendevstack/provision/util/rules/NamingRule.java
+++ b/src/main/java/org/opendevstack/provision/util/rules/NamingRule.java
@@ -1,0 +1,49 @@
+package org.opendevstack.provision.util.rules;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class NamingRule {
+    String reg;
+    Boolean not;
+    String description;
+    String errorMessage;
+
+    public String getReg() {
+        return reg;
+    }
+
+    public void setReg(String reg) {
+        this.reg = reg;
+    }
+
+    public Boolean getNot() {
+        return not;
+    }
+
+    public void setNot(Boolean not) {
+        this.not = not;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public boolean filter(String name) {
+        Matcher m = Pattern.compile(this.reg)
+                .matcher(name);
+        return  this.not ? !m.find() : m.find();
+    }
+}

--- a/src/main/resources/quickstarter-naming-rules.yml
+++ b/src/main/resources/quickstarter-naming-rules.yml
@@ -1,0 +1,14 @@
+---
+name: fe_angular
+rules:
+  - reg: -\d
+    not: true
+    description: No digits should follow '-' sign
+    errorMessage: Angular does not support '-' dirrectly followed by the number
+---
+name: be-node-express
+rules:
+  - reg: \\p{Lu}+
+    not: true
+    description: No upper-case letters
+    errorMessage: Node.js does not support upper-case project namings

--- a/src/test/java/org/opendevstack/provision/controller/E2EProjectAPIControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/E2EProjectAPIControllerTest.java
@@ -536,6 +536,7 @@ public class E2EProjectAPIControllerTest {
     // get the rundeck jobs
     List<Job> jobList =
         readTestDataTypeRef("rundeck-get-jobs-response", new TypeReference<List<Job>>() {});
+    jobList.stream().forEach(job -> job.setGroup("quickstarts"));
 
     mockHelper
         .mockExecute(

--- a/src/test/java/org/opendevstack/provision/controller/ProjectApiControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/ProjectApiControllerTest.java
@@ -620,10 +620,13 @@ public class ProjectApiControllerTest {
   }
 
   @Test
-  public void testFilterQuickstarters() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-    Method filterQuickstarters = ProjectApiController.class.getDeclaredMethod("filterQuickstarters", List.class);
+  public void testFilterQuickstarters()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Method filterQuickstarters =
+        ProjectApiController.class.getDeclaredMethod("filterQuickstarters", List.class);
     filterQuickstarters.setAccessible(true);
-    List<Map<String, String>> quickstartersFiltered = (List<Map<String, String>>) filterQuickstarters.invoke(apiController, data.quickstarters);
+    List<Map<String, String>> quickstartersFiltered =
+        (List<Map<String, String>>) filterQuickstarters.invoke(apiController, data.quickstarters);
     assertEquals(quickstartersFiltered.size(), 1);
   }
 


### PR DESCRIPTION
Introduced logic for  building quickstarter naming convention .

1. Created configuration file with requirements for names selection accordingly to project names supported by different frameworks.
2. Created endpoint for front-end to extract information about specified naming rules.
3. Created filtering logic for processes of creation of a new project as well as update existing one.