### PR TITLE
Revert "Bump bootstrap from 3.3.7 to 4.3.1"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     //frontend webjars
     compile 'org.webjars:webjars-locator:0.37'
     compile 'org.webjars.bower:jquery:3.4.1'
-    compile 'org.webjars.bower:bootstrap:4.3.1'
+    compile 'org.webjars.bower:bootstrap:3.3.7'
     compile 'org.webjars.bower:react:16.1.0'
     compile 'org.webjars.bower:font-awesome:4.7.0'
     compile 'org.webjars.bower:lodash:4.17.10'


### PR DESCRIPTION
Reverts opendevstack/ods-provisioning-app#218 , since this change breaks the entire navigation bar.

Changes between bootstrap v3.x.x and  v4.0.0 are documented at https://getbootstrap.com/docs/4.0/migration/#by-component

Migrating to v4. has to be implemented and tested carefully.