### PR TITLE
Configure ods image and ref

### DIFF
--- a/ocp-config/prov-app/cm.yml
+++ b/ocp-config/prov-app/cm.yml
@@ -25,7 +25,7 @@ parameters:
   description: the API host of the OCP cluster
 - name: OPENSHIFT_CONSOLE_HOST
   required: true
-  description: the console host of the OCP cluster 
+  description: the console host of the OCP cluster
 - name: PROV_APP_CROWD_USER_GROUP
   required: true
   description: crowd user group
@@ -171,7 +171,7 @@ objects:
       jenkinspipeline.quickstarter.feIonic.desc=Mobile - Ionic
       jenkinspipeline.quickstarter.feIonic.url=opendevstack/ods-quickstarters.git#production/fe-ionic/Jenkinsfile
 
-      # Other Quickstarters
+      # Other quickstarters
       jenkinspipeline.quickstarter.beAirflow.desc=Other - Airflow
       jenkinspipeline.quickstarter.beAirflow.url=opendevstack/ods-quickstarters.git#production/be-airflow/Jenkinsfile
       jenkinspipeline.quickstarter.e2eCypress.desc=Other - Cypress E2E test

--- a/ocp-config/prov-app/cm.yml
+++ b/ocp-config/prov-app/cm.yml
@@ -1,5 +1,72 @@
 apiVersion: v1
 kind: Template
+parameters:
+- name: ODS_IMAGE_TAG
+  required: true
+- name: ODS_GIT_REF
+  required: true
+- name: PROV_APP_JIRA_URI
+  required: true
+  description: the URI of JIRA used to create new jira projects
+- name: PROV_APP_CONFLUENCE_URI
+  required: true
+  description: the URI of confluence used to create new confluence spaces
+- name: PROV_APP_BITBUCKET_URI
+  required: true
+  description: the URI of bitbucket used to create new project and repositories
+- name: PROV_APP_RUNDECK_URI
+  required: true
+  description: the URI of rundeck used to kickstart provisioning projects and components
+- name: PROV_APP_CROWD_URI
+  required: true
+  description: the URI of crowd used to authenticate users from the app against
+- name: OPENSHIFT_API_HOST
+  required: true
+  description: the API host of the OCP cluster
+- name: OPENSHIFT_CONSOLE_HOST
+  required: true
+  description: the console host of the OCP cluster 
+- name: PROV_APP_CROWD_USER_GROUP
+  required: true
+  description: crowd user group
+- name: CD_USER_ID
+  required: true
+  description: the username of the CD user
+- name: OPENSHIFT_APPS_BASEDOMAIN
+  required: true
+  description: the domain of routes exposed on OCP
+- name: PROV_APP_PACKAGE_PREFIX
+  required: true
+  description: the default package prefix
+- name: PROV_APP_ATLASSIAN_DOMAIN
+  required: true
+  description: the domain of the atlassian toolsuite needed for single signon cookies
+- name: PROV_APP_CROWD_PASSWORD
+  required: true
+  description: password of the crowd app to authenticate the provision app against
+- name: PROV_APP_JASYPT_PASSWORD
+  required: true
+- name: PROV_APP_MAIL_HOST
+  required: true
+  description: The hostname of the mailserver
+- name: PROV_APP_MAIL_PASSWORD
+  required: true
+  description: The password to authenticate against the mail server
+- name: PROV_APP_MAIL_USERNAME
+  required: true
+  description: The username to authenticate against the mail server
+- name: PROV_APP_CROWD_ADMIN_GROUP
+  required: true
+  description: The crowd admin group name
+- name: PROV_APP_PIPELINE_TRIGGER_SECRET
+  required: true
+  description: The trigger secret to pass to the webhook proxy
+- name: PROV_APP_LOG_LEVEL_ATLASSIAN_CROWD
+  required: true
+  description: Log level of Atlassian crowd package
+- name: PROV_APP_LOG_LEVEL_OPENDEVSTACK
+  required: true
+  description: Log level of OpenDevStack package
 objects:
 - kind: ConfigMap
   metadata:
@@ -63,11 +130,16 @@ objects:
       bitbucket.default.user.group=${PROV_APP_CROWD_USER_GROUP}
       bitbucket.technical.user=${CD_USER_ID}
 
-      #createProjects configuration
+      # ODS properties
+      ods.image-tag=${ODS_IMAGE_TAG}
+      ods.git-ref=${ODS_GIT_REF}
+
+      # createProjects configuration
       jenkinspipeline.quickstarter.create-projects.desc=Create Project. Only used internally, therefore separated from other quickstarters
       jenkinspipeline.quickstarter.create-projects.url=opendevstack/ods-core.git#production/create-projects/Jenkinsfile
       jenkinspipeline.quickstarter.create-projects.type=project
-      # Backend Quickstarter
+
+      # Backend quickstarters
       jenkinspipeline.quickstarter.beSpringBoot.desc=Backend - SpringBoot/Java
       jenkinspipeline.quickstarter.beSpringBoot.url=opendevstack/ods-quickstarters.git#production/be-java-springboot/Jenkinsfile
       jenkinspipeline.quickstarter.dockerPlain.desc=Backend - Docker/Plain
@@ -81,7 +153,7 @@ objects:
       jenkinspipeline.quickstarter.beTypescriptExpress.desc=Backend - NodeJS/Express
       jenkinspipeline.quickstarter.beTypescriptExpress.url=opendevstack/ods-quickstarters.git#production/be-typescript-express/Jenkinsfile
 
-      # Data Science quickstarter
+      # Data Science quickstarters
       jenkinspipeline.quickstarter.dsJupyterNotebook.desc=Data Science - Jupyter Notebook
       jenkinspipeline.quickstarter.dsJupyterNotebook.url=opendevstack/ods-quickstarters.git#production/ds-jupyter-notebook/Jenkinsfile
       jenkinspipeline.quickstarter.dsRshiny.desc=Data Science - R-Shiny
@@ -89,7 +161,7 @@ objects:
       jenkinspipeline.quickstarter.dsMlService.desc=Data Science - Machine Learning
       jenkinspipeline.quickstarter.dsMlService.url=opendevstack/ods-quickstarters.git#production/ds-ml-service/Jenkinsfile
 
-      # Frontend Quickstarter
+      # Frontend quickstarters
       jenkinspipeline.quickstarter.feAngular.desc=Frontend - Angular
       jenkinspipeline.quickstarter.feAngular.url=opendevstack/ods-quickstarters.git#production/fe-angular/Jenkinsfile
       jenkinspipeline.quickstarter.feReact.desc=Frontend - React
@@ -99,14 +171,14 @@ objects:
       jenkinspipeline.quickstarter.feIonic.desc=Mobile - Ionic
       jenkinspipeline.quickstarter.feIonic.url=opendevstack/ods-quickstarters.git#production/fe-ionic/Jenkinsfile
 
-      #Other Quickstarter
+      # Other Quickstarters
       jenkinspipeline.quickstarter.beAirflow.desc=Other - Airflow
       jenkinspipeline.quickstarter.beAirflow.url=opendevstack/ods-quickstarters.git#production/be-airflow/Jenkinsfile
       jenkinspipeline.quickstarter.e2eCypress.desc=Other - Cypress E2E test
       jenkinspipeline.quickstarter.e2eCypress.url=opendevstack/ods-quickstarters.git#production/e2e-cypress/Jenkinsfile
       jenkinspipeline.quickstarter.releaseManager.desc=Other - Releasemanager
       jenkinspipeline.quickstarter.releaseManager.url=opendevstack/ods-quickstarters.git#production/release-manager/Jenkinsfile
-      
+
       # openshift properties
       openshift.apps.basedomain=${OPENSHIFT_APPS_BASEDOMAIN}
       openshift.console.uri=${OPENSHIFT_CONSOLE_HOST}/console/project/
@@ -178,66 +250,3 @@ objects:
       spring.mail.password=${PROV_APP_MAIL_PASSWORD}
       provison.mail.sender=provision@${PROV_APP_MAIL_HOST}
       spring.main.allow-bean-definition-overriding=true
-parameters:
-- name: PROV_APP_JIRA_URI
-  required: true
-  description: the URI of JIRA used to create new jira projects  
-- name: PROV_APP_CONFLUENCE_URI
-  required: true
-  description: the URI of confluence used to create new confluence spaces
-- name: PROV_APP_BITBUCKET_URI
-  required: true
-  description: the URI of bitbucket used to create new project and repositories  
-- name: PROV_APP_RUNDECK_URI
-  required: true
-  description: the URI of rundeck used to kickstart provisioning projects and components  
-- name: PROV_APP_CROWD_URI
-  required: true
-  description: the URI of crowd used to authenticate users from the app against    
-- name: OPENSHIFT_API_HOST
-  required: true
-  description: the API host of the OCP cluster   
-- name: OPENSHIFT_CONSOLE_HOST
-  required: true
-  description: the console host of the OCP cluster 
-- name: PROV_APP_CROWD_USER_GROUP
-  required: true
-  description: crowd user group     
-- name: CD_USER_ID
-  required: true
-  description: the username of the CD user     
-- name: OPENSHIFT_APPS_BASEDOMAIN
-  required: true
-  description: the domain of routes exposed on OCP   
-- name: PROV_APP_PACKAGE_PREFIX
-  required: true
-  description: the default package prefix   
-- name: PROV_APP_ATLASSIAN_DOMAIN
-  required: true
-  description: the domain of the atlassian toolsuite needed for single signon cookies  
-- name: PROV_APP_CROWD_PASSWORD
-  required: true
-  description: password of the crowd app to authenticate the provision app against
-- name: PROV_APP_JASYPT_PASSWORD
-  required: true
-- name: PROV_APP_MAIL_HOST
-  required: true
-  description: The hostname of the mailserver
-- name: PROV_APP_MAIL_PASSWORD
-  required: true
-  description: The password to authenticate against the mail server
-- name: PROV_APP_MAIL_USERNAME
-  required: true
-  description: The username to authenticate against the mail server
-- name: PROV_APP_CROWD_ADMIN_GROUP
-  required: true
-  description: The crowd admin group name
-- name: PROV_APP_PIPELINE_TRIGGER_SECRET
-  required: true
-  description: The trigger secret to pass to the webhook proxy
-- name: PROV_APP_LOG_LEVEL_ATLASSIAN_CROWD
-  required: true
-  description: Log level of Atlassian crowd package
-- name: PROV_APP_LOG_LEVEL_OPENDEVSTACK
-  required: true
-  description: Log level of OpenDevStack package

--- a/src/main/java/org/opendevstack/provision/services/JenkinsPipelineAdapter.java
+++ b/src/main/java/org/opendevstack/provision/services/JenkinsPipelineAdapter.java
@@ -82,6 +82,12 @@ public class JenkinsPipelineAdapter extends BaseServiceAdapter implements IJobEx
   @Value("${bitbucket.uri}")
   private String bitbucketUri;
 
+  @Value("${ods.image-tag}")
+  private String odsImageTag;
+
+  @Value("${ods.git-ref}")
+  private String odsGitRef;
+
   private List<Job> componentQuickstarters;
 
   public JenkinsPipelineAdapter() {
@@ -128,6 +134,8 @@ public class JenkinsPipelineAdapter extends BaseServiceAdapter implements IJobEx
         options.put("GROUP_ID", groupId);
         options.put("PROJECT_ID", project.projectKey.toLowerCase());
         options.put("PACKAGE_NAME", packageName);
+        options.put("ODS_IMAGE_TAG", odsImageTag);
+        options.put("ODS_GIT_REF", odsGitRef);
 
         String triggerSecret =
             project.webhookProxySecret != null
@@ -180,6 +188,9 @@ public class JenkinsPipelineAdapter extends BaseServiceAdapter implements IJobEx
         logger.debug("project id: {} admin: {}", project.projectKey, getUserName());
         options.put("PROJECT_ADMIN", getUserName());
       }
+
+      options.put("ODS_IMAGE_TAG", odsImageTag);
+      options.put("ODS_GIT_REF", odsGitRef);
       ExecutionsData data =
           prepareAndExecuteJob(
               new Job(jenkinsPipelineProperties.getCreateProjectQuickstarter()),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -97,7 +97,9 @@ rundeck.artifact.pattern=%s-%s
 rundeck.project.group.quickstarter=quickstarts
 rundeck.project.group.openshift=openshift
 
-
+# ODS properties
+ods.image-tag=latest
+ods.git-ref=production
 
 #openshift properties
 # allow upgrade of a jira only project

--- a/src/main/resources/templates/provision.html
+++ b/src/main/resources/templates/provision.html
@@ -250,7 +250,7 @@
                                 </div>
 								<div class="row">
                                     <div class="col-xs-8 col-sm-6">
-                                        Provisioniong jobs:
+                                        Provisioning jobs:
                                     </div>
                                     <div class="col-xs-4 col-sm-6" id="dataJobUrls"></div>
                                 </div>                                


### PR DESCRIPTION
There is some overlap now with the configuration of the quickstarters, but I don't want to change that before @stefanlack your changes with the description are in.

This change allows to configure the ref/image to use e.g. in the quickstarter Jenkinsfiles, which makes it quite easy to change out new stuff :)