### PR TITLE
Add CD_USER_TYPE param

### DIFF
--- a/src/main/java/org/opendevstack/provision/services/JenkinsPipelineAdapter.java
+++ b/src/main/java/org/opendevstack/provision/services/JenkinsPipelineAdapter.java
@@ -207,10 +207,13 @@ public class JenkinsPipelineAdapter extends BaseServiceAdapter implements IJobEx
         Base64.getEncoder().encodeToString(project.webhookProxySecret.getBytes()));
 
     String projectCdUser = generalCdUser;
+    String cdUserType = "general";
     if (project.cdUser != null && !project.cdUser.trim().isEmpty()) {
       projectCdUser = project.cdUser;
+      cdUserType = "project";
     }
 
+    options.put("CD_USER_TYPE", cdUserType);
     options.put("CD_USER_ID_B64", Base64.getEncoder().encodeToString(projectCdUser.getBytes()));
 
     try {


### PR DESCRIPTION
The Jenkins job can use it to figure out if the
passed user is the general one or a project specific one.

Addresses https://github.com/opendevstack/ods-core/issues/314.