### PR TITLE
Catch custom exception early to return 401

### DIFF
--- a/src/main/java/org/opendevstack/provision/controller/ProjectApiController.java
+++ b/src/main/java/org/opendevstack/provision/controller/ProjectApiController.java
@@ -35,6 +35,7 @@ import org.opendevstack.provision.adapter.IServiceAdapter;
 import org.opendevstack.provision.adapter.IServiceAdapter.CLEANUP_LEFTOVER_COMPONENTS;
 import org.opendevstack.provision.adapter.IServiceAdapter.LIFECYCLE_STAGE;
 import org.opendevstack.provision.adapter.IServiceAdapter.PROJECT_TEMPLATE;
+import org.opendevstack.provision.authentication.MissingCredentialsInfoException;
 import org.opendevstack.provision.model.ExecutionJob;
 import org.opendevstack.provision.model.ExecutionsData;
 import org.opendevstack.provision.model.OpenProjectData;
@@ -308,6 +309,8 @@ public class ProjectApiController {
       mailAdapter.notifyUsersAboutProject(storedExistingProject);
 
       return ResponseEntity.ok().body(storedExistingProject);
+    } catch (MissingCredentialsInfoException ex) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     } catch (Exception exProvision) {
       Map<CLEANUP_LEFTOVER_COMPONENTS, Integer> cleanupResults =
           cleanup(LIFECYCLE_STAGE.QUICKSTARTER_PROVISION, updatedProject);


### PR DESCRIPTION
FYI @stitakis @clemensutschig @herrkoch This fixes yet another flow that was not handled correctly ... in theory there can be more placed like this ... but in testing this seems to be it. We must find another way to deal with the whole thing in ODS 3.