### PR TITLE
Use image tag "latest" for prov-app

### DIFF
--- a/ocp-config/prov-app/dc.yml
+++ b/ocp-config/prov-app/dc.yml
@@ -3,8 +3,6 @@ kind: Template
 parameters:
 - name: TAILOR_NAMESPACE
   required: true
-- name: ODS_IMAGE_TAG
-  required: true
 objects:
 - apiVersion: v1
   kind: DeploymentConfig
@@ -28,7 +26,7 @@ objects:
           app: prov-app
       spec:
         containers:
-        - image: ${TAILOR_NAMESPACE}/prov-app:${ODS_IMAGE_TAG}
+        - image: ${TAILOR_NAMESPACE}/prov-app:latest
           imagePullPolicy: IfNotPresent
           name: prov-app
           ports:
@@ -70,7 +68,7 @@ objects:
         - prov-app
         from:
           kind: ImageStreamTag
-          name: prov-app:${ODS_IMAGE_TAG}
+          name: prov-app:latest
           namespace: ${TAILOR_NAMESPACE}
       type: ImageChange
     - type: ConfigChange


### PR DESCRIPTION
As the deployment happens via Jenkins, the "latest" tag is set.

While we still have the prov-dev/prov-test setup, this is the best
configuration. If and when there is a prov-app installation in the "cd"
namespace, then this should probably be tagged with ODS_IMAGE_TAG. But
will do that then ...

Fixes #331.