### PR TITLE
switch to java 11 and use adoptopenjdk 11 image based on UBI minimal

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Build with Gradle
       run: ./gradlew clean spotlessCheck test
       env:

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ apply plugin: 'io.spring.dependency-management'
 
 group = 'prov'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = 1.8
+sourceCompatibility = 1.11
 
 repositories {
     if (no_nexus) {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM adoptopenjdk/openjdk11:ubi-minimal-jre
  
 COPY app.jar app.jar
 


### PR DESCRIPTION
switches java version to 11 and uses the adoptopenjdk 11 image based on UBI minimal.
For more information on UBI see https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image.