### PR TITLE
adds default value for logback file path backport 2.x

### DIFF
--- a/ocp-config/prov-app/cm.yml
+++ b/ocp-config/prov-app/cm.yml
@@ -67,9 +67,6 @@ parameters:
 - name: PROV_APP_LOG_LEVEL_OPENDEVSTACK
   required: true
   description: Log level of OpenDevStack package
-- name: LOGGING_FILE_PATH
-  required: true
-  description: File system location for the log files
 objects:
 - kind: ConfigMap
   metadata:
@@ -86,9 +83,6 @@ objects:
       logging.level.com.atlassian=INFO
       logging.level.com.atlassian.crowd=${PROV_APP_LOG_LEVEL_ATLASSIAN_CROWD}
       logging.level.org.opendevstack=${PROV_APP_LOG_LEVEL_OPENDEVSTACK}
-
-      # log file
-      logging.file.path=${LOGGING_FILE_PATH}
 
       # atlassian API calls take sooo long
       server.servlet.session.timeout=240

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
 <configuration>
 
 	<!-- home of the logs -->
-	<property name="PROV_HIST_HOME" value="${LOG_PATH}" />
+	<springProperty scope="context" name="PROV_HIST_HOME" source="logging.file.path" defaultValue="/opt/provision/history/logs"/>
 
 	<!-- custom file appender -->"
 	<appender name="FILE-THREAD" class="ch.qos.logback.classic.sift.SiftingAppender">


### PR DESCRIPTION
Fixes #384 
Adds backward compatibility for logback configuration. File path defaults to old value. 