### PR TITLE
Specify resource constraints on DeploymentConfig

### DIFF
--- a/ocp-config/prov-app/dc.yml
+++ b/ocp-config/prov-app/dc.yml
@@ -34,9 +34,11 @@ objects:
             protocol: TCP
           resources:
             limits:
-              memory: 3Gi
+              cpu: "1"
+              memory: 1Gi
             requests:
-              memory: 100Mi
+              cpu: 100m
+              memory: 512Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:


### PR DESCRIPTION
Typical memory usage seems to hover around 350Mi, so using 512Mi/1Gi
should be fine.

Typical CPU usage is well below 100m - however during boot, it is really
helpful to have lots of CPU available, therefore we limit to 1 core.

Fixes #396.