### PR TITLE
change certificate authority configuration to runtime instead of imag…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ gradle.properties
 /src/main/resources/application-testods.properties
 
 /src/main/resources/history-local/
+
+.DS_Store

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,8 +37,6 @@ def stageBuild(def context) {
     springBootEnv = 'dev'
   }
   stage('Build') {
-    sh 'echo ${APP_DNS}'
-    sh 'openssl s_client -showcerts -connect ${APP_DNS}:443 < /dev/null | openssl x509 -outform DER > docker/derp.der'
     withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_USERNAME=${context.nexusUsername}", "NEXUS_PASSWORD=${context.nexusPassword}", "NEXUS_HOST=${context.nexusHost}", "JAVA_OPTS=${javaOpts}","GRADLE_TEST_OPTS=${gradleTestOpts}","ENVIRONMENT=${springBootEnv}"]) {
       def status = sh(script: "./gradlew clean build --stacktrace --no-daemon", returnStatus: true)
       if (status != 0) {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,8 +7,7 @@ EXPOSE 8080
 
 ENV CA_CERT none
 
-RUN chgrp -R 0 /opt/java/openjdk/lib/security && \
-    chmod -R g+rwX /opt/java/openjdk/lib/security
+RUN chmod g+w /opt/java/openjdk/lib/security/cacerts
 
 VOLUME /opt/provision/history
 VOLUME /config

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,18 @@
 FROM adoptopenjdk/openjdk11:ubi-minimal-jre
  
+COPY files/entrypoint.sh /usr/local/bin/
 COPY app.jar app.jar
-
-
-#Import base domain wildcard certificate
-RUN echo $JAVA_HOME
-COPY derp.der derp.der
-RUN echo yes | $JAVA_HOME/bin/keytool -importcert -alias oc-root -keystore  $JAVA_HOME/lib/security/cacerts -storepass changeit -file /derp.der
 
 EXPOSE 8080
 
-CMD ["java", "-jar", "app.jar", "--spring.config.location=file:/config/application.properties"]
+ENV CA_CERT none
+
+RUN chgrp -R 0 /opt/java/openjdk/lib/security && \
+    chmod -R g+rwX /opt/java/openjdk/lib/security
+
+VOLUME /opt/provision/history
+VOLUME /config
+VOLUME /opt/provision/ca_cert
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["java", "-jar", "app.jar", "--spring.config.location=file:/config/"]

--- a/docker/files/entrypoint.sh
+++ b/docker/files/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+# By default if NO CA_CERT env is passed, the entrypoint tries to find the Openshift default CA and import it into the cacerts of the JVM.
+# If a certificate is passed via the CA_CERT env it is tried to find it in the volume mount /opt/provision/ca_cert.
+# If no certificate is configured and the Openshift default can not be found (e.g. running locally) the prov app will start without importing an additional CA cert.
+
+# Openshift default CA. See https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets
+SERVICEACCOUNT_CA='/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt'
+CA_CERT_PATH='/opt/provision/ca_cert'
+
+IMPORT_CA='none'
+if [[ $CA_CERT == 'none' ]]; then
+  echo "INFO: no CA_CERT configured checking for default '$SERVICEACCOUNT_CA'"
+
+  if [[ -f $SERVICEACCOUNT_CA ]]; then
+    echo "INFO: found $SERVICEACCOUNT_CA"
+    IMPORT_CA=$SERVICEACCOUNT_CA
+  else
+    echo "INFO: could not find '$SERVICEACCOUNT_CA'"
+  fi
+
+else
+  echo "INFO: CA_CERT is set to '$CA_CERT'"
+
+  if [[ -f "$CA_CERT_PATH/$CA_CERT" ]]; then
+    echo "INFO: found $CA_CERT_PATH/$CA_CERT"
+    IMPORT_CA="$CA_CERT_PATH/$CA_CERT"
+  else
+    echo "WARN: CA_CERT is set but could not be found, maybe you forgot to mount '$CA_CERT_PATH' ?"
+    exit 1
+  fi
+
+fi
+
+if [[ $IMPORT_CA != 'none' ]]; then
+  echo "INFO: importing '$IMPORT_CA' into cacerts"
+  keytool -importcert -v -trustcacerts -alias user-ca-root -keystore $JAVA_HOME/lib/security/cacerts -storepass changeit -file $IMPORT_CA -noprompt
+else
+  echo "INFO: no CA imported"
+fi
+
+exec "$@"


### PR DESCRIPTION
This PR changes the way the prov-app configures the certificate authority.

Before the CA was baked into the image during image build time. This limited the flexibility (building locally, etc.) and was a blocker for publishing the container image to the public docker repo.

Now if not configure otherwise the default Openshift service-ca will be used. See https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets.
 