### PR TITLE
Add building and pushing the docker image to CI workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,8 +13,8 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Build with Gradle
-      run: ./gradlew clean spotlessCheck test
+    - name: Build provisioning-app
+      run: ./gradlew clean spotlessCheck build
       env:
         NO_NEXUS: true
     - uses: actions/cache@v1
@@ -23,3 +23,14 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
+    - name: Build docker image
+      if: success()
+      run: docker build -t ods-provisioning-app:local .
+      working-directory: docker
+    - name: Push docker image
+      if: success() && github.repository == 'opendevstack/ods-provisioning-app' && github.event_name == 'push'
+      shell: bash
+      env:
+        DOCKER_USER: ${{ secrets.DockerHubUser }}
+        DOCKER_PASS: ${{ secrets.DockerHubPass }}
+      run: ./.github/workflows/push-image.sh ${{ github.ref }} "$DOCKER_USER" "$DOCKER_PASS"

--- a/.github/workflows/push-image.sh
+++ b/.github/workflows/push-image.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -eu
+
+# This script will push a previously build ods-provisioning-app:local image with the corresponding tag to dockerhub.
+# The tag will be identified based on the passed GIT_REF.
+# We only create docker images for master (latest) and releases i.e. refs/heads/1.x, refs/heads/1.1.x, refs/tags/v1.0, refs/tags/v1.1.0
+
+shopt -s extglob
+
+GIT_REF=$1
+USER=$2
+PASSWORD=$3
+
+echo "GIT_REF=$GIT_REF"
+
+DOCKERTAG='none'
+
+# Examples for GIT_REF to DOCKERTAG mappings
+# master             -> latest
+# tag    'v.1.0'     -> 1.0
+# tag    'v.1.1.0'   -> 1.1.0
+# branch '1.x'       -> 1.x
+# branch '1.1.x'     -> 1.1.x
+# branch 'feature/x' -> none
+case $GIT_REF in
+  refs/heads/master )
+    DOCKERTAG='latest' ;;
+  refs/heads/?(+([0-9]).)+([0-9]).x )
+  	DOCKERTAG="${GIT_REF/refs\/heads\//}" ;;
+  refs/tags/v?(+([0-9]).)+([0-9]).*([0-9]) )
+    DOCKERTAG="${GIT_REF/refs\/tags\/v/}" ;;
+  * )
+    DOCKERTAG='none' ;;
+esac
+echo "DOCKERTAG=$DOCKERTAG"
+
+if [[ $DOCKERTAG != 'none' ]]; then
+  echo "Pushing docker image opendevstackorg/ods-provisioning-app:$DOCKERTAG"
+
+  echo "$PASSWORD" | docker login -u "$USER" --password-stdin
+  docker tag ods-provisioning-app:local opendevstackorg/ods-provisioning-app:$DOCKERTAG
+  docker push opendevstackorg/ods-provisioning-app:$DOCKERTAG
+  docker logout
+  rm -f /home/runner/.docker/config.json
+else
+  echo "NOT pushing a docker image for GIT_REF=$GIT_REF"
+fi


### PR DESCRIPTION
This PR adds building and pushing of the docker image to https://hub.docker.com/repository/docker/opendevstackorg/ods-provisioning-app to the GH CI workflow.
