### PR TITLE
add separate configuration for admin webhookproxy

### DIFF
--- a/openshift/cm.yml
+++ b/openshift/cm.yml
@@ -229,8 +229,17 @@ objects:
       openshift.test.project.name.pattern=%s%s-test
       openshift.dev.project.name.pattern=%s%s-dev
       openshift.cd.project.name.pattern=%s%s-cd
+
+      # the webhook proxy that proxies to the jenkins instance that creates and deletes projects. Usually you have one
+      # webhook proxy of this kind in an ods installation residing in the ods namespace.
+      openshift.jenkins.admin.webhookproxy.host=webhook-proxy-ods
+
+      # the webhook proxy of a created project that proxies to the projects jenkins to create / delete quickstarters
+      # or do builds based on commits to your projects components. Usually you have as many of this as you have ods projects
+      # in an ods installation.
       openshift.jenkins.project.name.pattern=jenkins-%s-cd%s
-      openshift.jenkins.webhookproxy.name.pattern=webhook-proxy-%s-cd%s
+      openshift.jenkins.project.webhookproxy.host.pattern=webhook-proxy-%s-cd%s
+
       openshift.jenkins.trigger.secret=${PROV_APP_PIPELINE_TRIGGER_SECRET}
 
       artifact.group.pattern=${PROV_APP_PACKAGE_PREFIX}.%s

--- a/src/main/java/org/opendevstack/provision/services/BitbucketAdapter.java
+++ b/src/main/java/org/opendevstack/provision/services/BitbucketAdapter.java
@@ -81,7 +81,7 @@ public class BitbucketAdapter extends BaseServiceAdapter implements ISCMAdapter 
   @Value("${openshift.apps.basedomain}")
   private String projectOpenshiftBaseDomain;
 
-  @Value("${openshift.jenkins.webhookproxy.name.pattern}")
+  @Value("${openshift.jenkins.project.webhookproxy.host.pattern}")
   private String projectOpenshiftJenkinsWebhookProxyNamePattern;
 
   @Value("${openshift.jenkins.trigger.secret}")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -83,8 +83,14 @@ openshift.console.uri=https://192.168.56.101:8443/console
 openshift.test.project.name.pattern=%s/project/%s-test
 openshift.dev.project.name.pattern=%s/project/%s-dev
 openshift.cd.project.name.pattern=%s/project/%s-cd
+# the webhook proxy that proxies to the jenkins instance that creates and deletes projects. Usually you have one
+# webhook proxy of this kind in an ods installation residing in the ods namespace.
+openshift.jenkins.admin.webhookproxy.host=webhook-proxy-ods
+# the webhook proxy of a created project that proxies to the projects jenkins to create / delete quickstarters
+# or do builds based on commits to your projects components. Usually you have as many of this as you have ods projects
+# in an ods installation.
 openshift.jenkins.project.name.pattern=jenkins-%s-cd%s
-openshift.jenkins.webhookproxy.name.pattern=webhook-proxy-%s-cd%s
+openshift.jenkins.project.webhookproxy.host.pattern=webhook-proxy-%s-cd%s
 openshift.jenkins.trigger.secret=secret101
 #Cookie Domain
 atlassian.domain=192.168.56.31

--- a/src/test/java/org/opendevstack/provision/controller/E2EProjectAPIControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/E2EProjectAPIControllerTest.java
@@ -494,7 +494,7 @@ public class E2EProjectAPIControllerTest {
                 .url(
                     containsString(
                         createJenkinsJobPath(
-                            "prov",
+                            "ods",
                             "create-projects/Jenkinsfile",
                             "ods-corejob-" + data.projectKey.toLowerCase())))
                 .bodyMatches(instanceOf(Execution.class))
@@ -655,7 +655,7 @@ public class E2EProjectAPIControllerTest {
     toClean.projectKey = createdProjectIncludingQuickstarters.projectKey;
     toClean.quickstarters = createdProjectIncludingQuickstarters.quickstarters;
 
-    mockExecuteAdminJob("prov", "delete-projects", "testp");
+    mockExecuteAdminJob("ods", "delete-projects", "testp");
     // delete whole projects (-cd, -dev and -test), calls
     // org.opendevstack.provision.controller.ProjectApiController.deleteProject
 
@@ -686,7 +686,7 @@ public class E2EProjectAPIControllerTest {
     toClean.quickstarters = createdProjectIncludingQuickstarters.quickstarters;
 
     String prefix = createdProjectIncludingQuickstarters.quickstarters.get(0).get("component_id");
-    mockExecuteAdminJob("testp", "delete-components", prefix);
+    mockExecuteAdminJob("testp-cd", "delete-components", prefix);
 
     // delete single component (via
     // org.opendevstack.provision.controller.ProjectApiController.deleteComponents)
@@ -929,7 +929,7 @@ public class E2EProjectAPIControllerTest {
   private String createJenkinsJobPath(String namespace, String jenkinsfilePath, String component) {
     return "https://webhook-proxy-"
         + namespace
-        + "-cd.192.168.56.101.nip.io/build?trigger_secret=secret101&jenkinsfile_path="
+        + ".192.168.56.101.nip.io/build?trigger_secret=secret101&jenkinsfile_path="
         + jenkinsfilePath
         + "&component="
         + component;

--- a/src/test/java/org/opendevstack/provision/services/JenkinsPipelineAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/JenkinsPipelineAdapterTest.java
@@ -71,7 +71,8 @@ public class JenkinsPipelineAdapterTest extends AbstractBaseServiceAdapterTest {
     jenkinsPipelineAdapter.jenkinsPipelineProperties = buildJenkinsPipelineProperties();
 
     jenkinsPipelineAdapter.groupPattern = "org.opendevstack.%s";
-    jenkinsPipelineAdapter.projectOpenshiftJenkinsWebhookProxyNamePattern = "webhook-proxy-%s-cd%s";
+    jenkinsPipelineAdapter.adminWebhookProxyHost = "webhook-proxy-ods";
+    jenkinsPipelineAdapter.projectWebhookProxyHostPattern = "webhook-proxy-%s-cd%s";
     jenkinsPipelineAdapter.projectOpenshiftJenkinsProjectPattern = "jenkins-%s-cd%s";
     jenkinsPipelineAdapter.projectOpenshiftBaseDomain = ".192.168.56.101.nip.io";
     jenkinsPipelineAdapter.projectOpenshiftCdProjectPattern = "%s/project/%s-cd";


### PR DESCRIPTION
Adds a separate configuration for the admin webhookproxy that proxies the create and delete project jobs defaulting to `webhook-proxy-ods`.

For the project webhook proxies that are created with each new project the pattern is still the same `webhook-proxy-${PROJECT_ID}-cd`