### PR TITLE
adds basic auth support to crowd auth provider

### DIFF
--- a/src/main/java/org/opendevstack/provision/authentication/crowd/CrowdAuthenticationManager.java
+++ b/src/main/java/org/opendevstack/provision/authentication/crowd/CrowdAuthenticationManager.java
@@ -54,6 +54,15 @@ public class CrowdAuthenticationManager implements AuthenticationManager, IODSAu
 
   @Autowired private SessionAwarePasswordHolder userPassword;
 
+  /**
+   * Constructor with secure SOAP restClient for crowd authentication
+   *
+   * @param securityServerClient
+   */
+  public CrowdAuthenticationManager(SecurityServerClient securityServerClient) {
+    this.securityServerClient = securityServerClient;
+  }
+
   /** @see IODSAuthnzAdapter#getUserPassword() */
   public String getUserPassword() {
     return userPassword.getPassword();
@@ -94,15 +103,6 @@ public class CrowdAuthenticationManager implements AuthenticationManager, IODSAu
   /** open for testing */
   public void setUserName(String userName) {
     this.userPassword.setUsername(userName);
-  }
-
-  /**
-   * Constructor with secure SOAP restClient for crowd authentication
-   *
-   * @param securityServerClient
-   */
-  public CrowdAuthenticationManager(SecurityServerClient securityServerClient) {
-    this.securityServerClient = securityServerClient;
   }
 
   /**

--- a/src/main/java/org/opendevstack/provision/authentication/crowd/CrowdSecurityConfiguration.java
+++ b/src/main/java/org/opendevstack/provision/authentication/crowd/CrowdSecurityConfiguration.java
@@ -83,7 +83,7 @@ public class CrowdSecurityConfiguration extends WebSecurityConfigurerAdapter {
   @Value("${crowd.cookie.domain}")
   String cookieDomain;
 
-  @Value("${provision.auth.provider.basic-auth.activate-beside-crowd}")
+  @Value("${provision.auth.basic-auth.enabled:true}")
   private boolean isBasicAuthEnabled;
 
   /**

--- a/src/main/java/org/opendevstack/provision/authentication/crowd/CrowdSecurityConfiguration.java
+++ b/src/main/java/org/opendevstack/provision/authentication/crowd/CrowdSecurityConfiguration.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 import net.sf.ehcache.CacheManager;
-import org.opendevstack.provision.authentication.SimpleCachingGroupMembershipManager;
 import org.opendevstack.provision.authentication.filter.SSOAuthProcessingFilter;
 import org.opendevstack.provision.authentication.filter.SSOAuthProcessingFilterBasicAuthHandler;
 import org.opendevstack.provision.authentication.filter.SSOAuthProcessingFilterBasicAuthStrategy;
@@ -328,8 +327,8 @@ public class CrowdSecurityConfiguration extends WebSecurityConfigurerAdapter {
     CrowdUserDetailsServiceImpl cusd = new CrowdUserDetailsServiceImpl();
     cusd.setUserManager(userManager());
     cusd.setGroupMembershipManager(
-        new SimpleCachingGroupMembershipManager(
-            securityServerClient(), userManager(), groupManager(), getCache()));
+        new ProvAppSimpleCachingGroupMembershipManager(
+            securityServerClient(), userManager(), groupManager(), getCache(), true));
     cusd.setAuthorityPrefix("");
     return cusd;
   }
@@ -341,7 +340,7 @@ public class CrowdSecurityConfiguration extends WebSecurityConfigurerAdapter {
    * @throws IOException
    */
   @Bean
-  RemoteCrowdAuthenticationProvider crowdAuthenticationProvider() throws IOException {
+  public RemoteCrowdAuthenticationProvider crowdAuthenticationProvider() throws IOException {
     return new RemoteCrowdAuthenticationProvider(
         crowdAuthenticationManager(), httpAuthenticator(), crowdUserDetailsService());
   }

--- a/src/main/java/org/opendevstack/provision/authentication/crowd/ProvAppSimpleCachingGroupMembershipManager.java
+++ b/src/main/java/org/opendevstack/provision/authentication/crowd/ProvAppSimpleCachingGroupMembershipManager.java
@@ -1,0 +1,43 @@
+package org.opendevstack.provision.authentication.crowd;
+
+import com.atlassian.crowd.exception.InvalidAuthenticationException;
+import com.atlassian.crowd.exception.InvalidAuthorizationTokenException;
+import com.atlassian.crowd.exception.UserNotFoundException;
+import com.atlassian.crowd.service.GroupManager;
+import com.atlassian.crowd.service.UserManager;
+import com.atlassian.crowd.service.cache.BasicCache;
+import com.atlassian.crowd.service.soap.client.SecurityServerClient;
+import java.rmi.RemoteException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.opendevstack.provision.authentication.SimpleCachingGroupMembershipManager;
+
+public class ProvAppSimpleCachingGroupMembershipManager
+    extends SimpleCachingGroupMembershipManager {
+
+  private final boolean lowercaseGroupNames;
+
+  public ProvAppSimpleCachingGroupMembershipManager(
+      SecurityServerClient securityServerClient,
+      UserManager userManager,
+      GroupManager groupManager,
+      BasicCache cache,
+      boolean lowercaseGroupNames) {
+    super(securityServerClient, userManager, groupManager, cache);
+    this.lowercaseGroupNames = lowercaseGroupNames;
+  }
+
+  @Override
+  public List getMemberships(String user)
+      throws RemoteException, InvalidAuthorizationTokenException, UserNotFoundException,
+          InvalidAuthenticationException {
+    List<String> memberships = super.getMemberships(user);
+    if (lowercaseGroupNames) {
+      List<String> membershipsAsLowercase =
+          memberships.stream().map(group -> group.toLowerCase()).collect(Collectors.toList());
+      return membershipsAsLowercase;
+    } else {
+      return memberships;
+    }
+  }
+}

--- a/src/main/java/org/opendevstack/provision/authentication/filter/SSOAuthProcessingFilter.java
+++ b/src/main/java/org/opendevstack/provision/authentication/filter/SSOAuthProcessingFilter.java
@@ -37,6 +37,8 @@ public class SSOAuthProcessingFilter extends CrowdSSOAuthenticationProcessingFil
 
   private HttpAuthenticator httpAuthenticator;
 
+  private SSOAuthProcessingFilterBasicAuthStrategy basicAuthHandlerStrategy;
+
   /**
    * Method to handle a successful authentication
    *
@@ -94,5 +96,23 @@ public class SSOAuthProcessingFilter extends CrowdSSOAuthenticationProcessingFil
 
   public HttpAuthenticator getAuthenticator() {
     return httpAuthenticator;
+  }
+
+  public void setBasicAuthHandlerStrategy(
+      SSOAuthProcessingFilterBasicAuthStrategy ssoFilterBasicAuthHandlerStrategy) {
+    this.basicAuthHandlerStrategy = ssoFilterBasicAuthHandlerStrategy;
+  }
+
+  @Override
+  protected boolean requiresAuthentication(
+      HttpServletRequest request, HttpServletResponse response) {
+
+    // For basic auth requires authentication should be skipped
+    // if security context already has an authentication object
+    if (!basicAuthHandlerStrategy.requiresAuthentication(request, response)) {
+      return false;
+    }
+
+    return super.requiresAuthentication(request, response);
   }
 }

--- a/src/main/java/org/opendevstack/provision/authentication/filter/SSOAuthProcessingFilterBasicAuthHandler.java
+++ b/src/main/java/org/opendevstack/provision/authentication/filter/SSOAuthProcessingFilterBasicAuthHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendevstack.provision.authentication.filter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/** @author Sebastian Titakis */
+public class SSOAuthProcessingFilterBasicAuthHandler
+    implements SSOAuthProcessingFilterBasicAuthStrategy {
+
+  private boolean isBasicAuthEnabled;
+
+  public SSOAuthProcessingFilterBasicAuthHandler(boolean isBasicAuthEnabled) {
+    this.isBasicAuthEnabled = isBasicAuthEnabled;
+  }
+
+  @Override
+  public boolean requiresAuthentication(HttpServletRequest request, HttpServletResponse response) {
+
+    // For basic auth requires authentication should be skipped
+    // if security context already has an authentication object
+    if (isBasicAuthEnabled) {
+      String authorization = request.getHeader("Authorization");
+      if (authorization != null && authorization.startsWith("Basic")) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (null != authentication && authentication.isAuthenticated()) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+}

--- a/src/main/java/org/opendevstack/provision/authentication/filter/SSOAuthProcessingFilterBasicAuthStrategy.java
+++ b/src/main/java/org/opendevstack/provision/authentication/filter/SSOAuthProcessingFilterBasicAuthStrategy.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendevstack.provision.authentication.filter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** @author Sebastian Titakis */
+public interface SSOAuthProcessingFilterBasicAuthStrategy {
+  boolean requiresAuthentication(HttpServletRequest request, HttpServletResponse response);
+}

--- a/src/main/java/org/opendevstack/provision/authentication/oauth2/BasicAuthConfig.java
+++ b/src/main/java/org/opendevstack/provision/authentication/oauth2/BasicAuthConfig.java
@@ -34,7 +34,7 @@ import org.opendevstack.provision.authentication.SimpleCachingGroupMembershipMan
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.cache.ehcache.EhCacheManagerFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,14 +42,13 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
 
 @Configuration
-@ConditionalOnProperty(
-    name = "provision.auth.provider.basic-auth.activate-beside-oauth2",
-    havingValue = "true")
+@ConditionalOnExpression(
+    "'${provision.auth.basic-auth.enabled}'=='true' && '${provision.auth.provider}'=='oauth2'")
 public class BasicAuthConfig {
 
   private static final Logger logger = LoggerFactory.getLogger(BasicAuthConfig.class);
 
-  @Value("${idmanager.realm}")
+  @Value("${idmanager.realm:provision}")
   private String idManagerRealm;
 
   @Value("${crowd.application.name}")

--- a/src/main/java/org/opendevstack/provision/authentication/oauth2/BasicAuthConfig.java
+++ b/src/main/java/org/opendevstack/provision/authentication/oauth2/BasicAuthConfig.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 import net.sf.ehcache.CacheManager;
-import org.opendevstack.provision.authentication.SimpleCachingGroupMembershipManager;
+import org.opendevstack.provision.authentication.crowd.ProvAppSimpleCachingGroupMembershipManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -112,8 +112,8 @@ public class BasicAuthConfig {
     CrowdUserDetailsServiceImpl cusd = new CrowdUserDetailsServiceImpl();
     cusd.setUserManager(userManager());
     cusd.setGroupMembershipManager(
-        new SimpleCachingGroupMembershipManager(
-            securityServerClient(), userManager(), groupManager(), getCache()));
+        new ProvAppSimpleCachingGroupMembershipManager(
+            securityServerClient(), userManager(), groupManager(), getCache(), true));
     cusd.setAuthorityPrefix("");
     return cusd;
   }

--- a/src/main/java/org/opendevstack/provision/authentication/oauth2/BasicAuthConfig.java
+++ b/src/main/java/org/opendevstack/provision/authentication/oauth2/BasicAuthConfig.java
@@ -12,7 +12,7 @@
  * the License.
  */
 
-package org.opendevstack.provision.authentication.basic;
+package org.opendevstack.provision.authentication.oauth2;
 
 import com.atlassian.crowd.integration.http.HttpAuthenticator;
 import com.atlassian.crowd.integration.http.HttpAuthenticatorImpl;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,7 @@ spring.session.timeout=480
 spring.mvc.async.request-timeout=90000
 # Switch authentication provider between 'crowd' or 'oauth2'.
 provision.auth.provider=crowd
+provision.auth.basic-auth.enabled=true
 # include crowd profile per default.
 project.template.default.key=default
 # add the ones (jira / confluence) you configured  below to this entry, comma separated

--- a/src/test/java/org/opendevstack/provision/authentication/basic/BasicAuthSecurityTestConfig.java
+++ b/src/test/java/org/opendevstack/provision/authentication/basic/BasicAuthSecurityTestConfig.java
@@ -39,9 +39,7 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationEn
  * @author Sebastian Titakis
  */
 @Configuration
-@ConditionalOnProperty(
-    name = "provision.auth.provider.basic-auth.activate-beside-oauth2",
-    havingValue = "utest")
+@ConditionalOnProperty(name = "provision.auth.basic-auth.enabled", havingValue = "utest")
 public class BasicAuthSecurityTestConfig {
 
   public static final String TEST_USER_USERNAME = "user";

--- a/src/test/java/org/opendevstack/provision/authentication/crowd/ProvAppSimpleCachingGroupMembershipManagerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/crowd/ProvAppSimpleCachingGroupMembershipManagerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendevstack.provision.authentication.crowd;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.atlassian.crowd.exception.InvalidAuthenticationException;
+import com.atlassian.crowd.exception.InvalidAuthorizationTokenException;
+import com.atlassian.crowd.exception.UserNotFoundException;
+import com.atlassian.crowd.service.GroupManager;
+import com.atlassian.crowd.service.UserManager;
+import com.atlassian.crowd.service.cache.BasicCache;
+import com.atlassian.crowd.service.soap.client.SecurityServerClient;
+import java.rmi.RemoteException;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/** @author Sebastian Titakis */
+@RunWith(SpringRunner.class)
+public class ProvAppSimpleCachingGroupMembershipManagerTest {
+
+  @MockBean private SecurityServerClient securityServerClient;
+
+  @MockBean private UserManager userManager;
+
+  @MockBean private GroupManager groupManager;
+
+  @MockBean private BasicCache cache;
+
+  @Test
+  public void getMemberships()
+      throws RemoteException, InvalidAuthorizationTokenException, UserNotFoundException,
+          InvalidAuthenticationException {
+
+    String groupInUppercase = "GROUP";
+
+    when(cache.getAllMemberships(anyString())).thenReturn(List.of(groupInUppercase));
+
+    // case memberships are not converted to lowercase
+    ProvAppSimpleCachingGroupMembershipManager membershipManager =
+        new ProvAppSimpleCachingGroupMembershipManager(
+            securityServerClient, userManager, groupManager, cache, false);
+
+    List<String> memberships = membershipManager.getMemberships("user");
+    assertTrue(memberships.contains(groupInUppercase));
+
+    // case memberships are converted to lowercase
+    membershipManager =
+        new ProvAppSimpleCachingGroupMembershipManager(
+            securityServerClient, userManager, groupManager, cache, true);
+
+    memberships = membershipManager.getMemberships("user");
+    assertTrue(memberships.contains(groupInUppercase.toLowerCase()));
+  }
+}

--- a/src/test/java/org/opendevstack/provision/authentication/filter/SSOAuthProcessingFilterBasicAuthHandlerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/filter/SSOAuthProcessingFilterBasicAuthHandlerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.opendevstack.provision.authentication.filter;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opendevstack.provision.authentication.TestAuthentication;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.TestSecurityContextHolder;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/** @author Sebastian Titakis */
+@RunWith(SpringRunner.class)
+public class SSOAuthProcessingFilterBasicAuthHandlerTest {
+
+  @MockBean private HttpServletRequest request;
+
+  @MockBean private HttpServletResponse response;
+
+  @Test
+  public void requiresAuthentication() {
+
+    // if basic auth is not enabled always return true
+    SSOAuthProcessingFilterBasicAuthHandler handler =
+        new SSOAuthProcessingFilterBasicAuthHandler(false);
+    assertTrue(handler.requiresAuthentication(request, response));
+
+    // Request has to include basic auth header
+    when(request.getHeader("Authorization")).thenReturn("Basic adfafadfdsfdsf");
+
+    // if basic auth is enabled and no authentication object exists in security context returns true
+    handler = new SSOAuthProcessingFilterBasicAuthHandler(true);
+    assertTrue(handler.requiresAuthentication(request, response));
+
+    TestAuthentication testAuthentication = new TestAuthentication();
+    TestSecurityContextHolder.getContext().setAuthentication(testAuthentication);
+
+    // if basic auth is enabled and authentication object exists in security context but is not
+    // authenticated return true
+    handler = new SSOAuthProcessingFilterBasicAuthHandler(true);
+    assertTrue(handler.requiresAuthentication(request, response));
+
+    // if basic auth is enabled and no authentication object exists in security context but is
+    // authenticated false
+    handler = new SSOAuthProcessingFilterBasicAuthHandler(true);
+    testAuthentication.setAuthenticated(true);
+    assertFalse(handler.requiresAuthentication(request, response));
+  }
+}

--- a/src/test/java/org/opendevstack/provision/controller/DefaultControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/DefaultControllerTest.java
@@ -22,9 +22,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.opendevstack.provision.SpringBoot;
 import org.opendevstack.provision.adapter.IBugtrackerAdapter;
 import org.opendevstack.provision.adapter.ICollaborationAdapter;
@@ -36,9 +34,10 @@ import org.opendevstack.provision.model.AboutChangesData;
 import org.opendevstack.provision.services.StorageAdapter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -49,35 +48,36 @@ import org.springframework.web.context.WebApplicationContext;
 
 /** Created by TJA on 29.06.2017. */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = SpringBoot.class)
-@DirtiesContext
-@WithMockUser(username = "test")
-@ActiveProfiles("crowd")
+@SpringBootTest(webEnvironment = WebEnvironment.MOCK, classes = SpringBoot.class)
+// @DirtiesContext
+// @DirtiesContext
+// @WithMockUser(username = "test")
+@ActiveProfiles("crowd,utestcrowd,quickstarters")
 public class DefaultControllerTest {
 
-  private MockMvc mockMvc;
+  @MockBean private IJobExecutionAdapter jobExecutionAdapter;
 
-  @Autowired DefaultController defaultController;
+  @MockBean private StorageAdapter storageAdapter;
 
-  @Mock IJobExecutionAdapter jobExecutionAdapter;
+  @MockBean private CrowdAuthenticationManager crowdAuthenticationManager;
 
-  @Mock CrowdAuthenticationManager crowdAuthenticationManager;
-
-  @Mock StorageAdapter storageAdapter;
+  @Autowired private DefaultController defaultController;
 
   @Autowired private WebApplicationContext context;
 
-  @Autowired IJobExecutionAdapter realJobExecutionAdapter;
+  //  @Autowired private IJobExecutionAdapter realJobExecutionAdapter;
 
-  @Autowired ISCMAdapter realBitbucketAdapter;
+  @Autowired private ISCMAdapter realBitbucketAdapter;
 
-  @Autowired IBugtrackerAdapter realJiraAdapter;
+  @Autowired private IBugtrackerAdapter realJiraAdapter;
 
-  @Autowired ICollaborationAdapter realConfluenceAdapter;
+  @Autowired private ICollaborationAdapter realConfluenceAdapter;
+
+  private MockMvc mockMvc;
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    //    MockitoAnnotations.initMocks(this);
 
     mockMvc =
         MockMvcBuilders.webAppContextSetup(context)

--- a/src/test/java/org/opendevstack/provision/controller/DefaultControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/DefaultControllerTest.java
@@ -49,9 +49,6 @@ import org.springframework.web.context.WebApplicationContext;
 /** Created by TJA on 29.06.2017. */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.MOCK, classes = SpringBoot.class)
-// @DirtiesContext
-// @DirtiesContext
-// @WithMockUser(username = "test")
 @ActiveProfiles("crowd,utestcrowd,quickstarters")
 public class DefaultControllerTest {
 
@@ -65,8 +62,6 @@ public class DefaultControllerTest {
 
   @Autowired private WebApplicationContext context;
 
-  //  @Autowired private IJobExecutionAdapter realJobExecutionAdapter;
-
   @Autowired private ISCMAdapter realBitbucketAdapter;
 
   @Autowired private IBugtrackerAdapter realJiraAdapter;
@@ -76,12 +71,10 @@ public class DefaultControllerTest {
   private MockMvc mockMvc;
 
   @Before
-  public void setUp() throws Exception {
-    //    MockitoAnnotations.initMocks(this);
+  public void setUp() {
 
     mockMvc =
         MockMvcBuilders.webAppContextSetup(context)
-            // .apply(SecurityMockMvcConfigurers.springSecurity())
             .build();
   }
 

--- a/src/test/java/org/opendevstack/provision/controller/DefaultControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/DefaultControllerTest.java
@@ -73,9 +73,7 @@ public class DefaultControllerTest {
   @Before
   public void setUp() {
 
-    mockMvc =
-        MockMvcBuilders.webAppContextSetup(context)
-            .build();
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
   }
 
   @Test

--- a/src/test/java/org/opendevstack/provision/controller/ProjectApiControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/ProjectApiControllerTest.java
@@ -52,10 +52,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.GrantedAuthority;
@@ -77,7 +75,6 @@ import org.springframework.web.context.WebApplicationContext;
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = SpringBoot.class)
-@AutoConfigureMockMvc
 @ActiveProfiles("crowd,utestcrowd,quickstarters")
 public class ProjectApiControllerTest {
 
@@ -106,11 +103,6 @@ public class ProjectApiControllerTest {
   @Autowired private List<String> projectTemplateKeyNames;
 
   @Autowired private WebApplicationContext context;
-
-  @Autowired private ApplicationContext applicationContext;
-
-  @Value("${idmanager.group.opendevstack-users}")
-  private String roleUser;
 
   @Value("${idmanager.group.opendevstack-administrators}")
   private String roleAdmin;

--- a/src/test/java/org/opendevstack/provision/util/rest/RestClientTest.java
+++ b/src/test/java/org/opendevstack/provision/util/rest/RestClientTest.java
@@ -15,7 +15,7 @@
 package org.opendevstack.provision.util.rest;
 
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -34,8 +34,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -45,11 +43,6 @@ import org.springframework.test.context.junit4.SpringRunner;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = SpringBoot.class)
-@DirtiesContext
-@WithMockUser(
-    username = "testUser",
-    roles = {"ADMIN"},
-    password = "testUser")
 @ActiveProfiles("crowd")
 public class RestClientTest {
 
@@ -58,16 +51,13 @@ public class RestClientTest {
 
   private RestClient client;
 
-  @Value("${crowd.sso.cookie.name}")
-  private String crowdSSOCookieName;
-
   @Autowired CrowdAuthenticationManager manager;
 
   @Before
   public void setUp() {
     client = new RestClient();
-    client.setConnectTimeout(1);
-    client.setReadTimeout(1);
+    client.setConnectTimeout(5);
+    client.setReadTimeout(5);
     client.afterPropertiesSet();
   }
 
@@ -77,21 +67,20 @@ public class RestClientTest {
   }
 
   @Test
-  public void callHttpGreen() throws Exception {
-    RestClientCall call = validGetCall();
-    String response = client.execute(call);
-
-    assertNotNull(response);
+  public void callHttpNotAuthorized() {
+    try {
+      RestClientCall call = validGetCall();
+      call.basicAuthenticated(new CredentialsInfo("unknow_user", "secret"));
+      client.execute(call);
+      fail();
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("Errorcode: 401"));
+    }
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void callHttpMissingUrl() throws Exception {
     client.execute(validGetCall().url(null));
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void callAuthWithoutCredentials() throws Exception {
-    client.execute(validGetCall().credentials(null));
   }
 
   @Test
@@ -109,7 +98,6 @@ public class RestClientTest {
 
   public RestClientCall validGetCall() {
     return RestClientCall.get()
-        .basicAuthenticated(new CredentialsInfo("testUser", "testUser"))
         .url(String.format("http://localhost:%d", randomServerPort))
         .mediaType(MediaType.parse("application/xhtml+xml"))
         .returnType(String.class);

--- a/src/test/resources/application-crowd.properties
+++ b/src/test/resources/application-crowd.properties
@@ -19,4 +19,4 @@ crowd.local.directory=LocalDirectory
 crowd.sso.cookie.name=crowd.token_key
 
 provision.auth.provider=crowd
-provision.auth.provider.basic-auth.activate-beside-crowd=true
+provision.auth.basic-auth.enabled=true

--- a/src/test/resources/application-crowd.properties
+++ b/src/test/resources/application-crowd.properties
@@ -19,4 +19,4 @@ crowd.local.directory=LocalDirectory
 crowd.sso.cookie.name=crowd.token_key
 
 provision.auth.provider=crowd
-
+provision.auth.provider.basic-auth.activate-beside-crowd=true

--- a/src/test/resources/application-utest.properties
+++ b/src/test/resources/application-utest.properties
@@ -1,7 +1,7 @@
 # This disables security config
 provision.auth.provider=oauth2
 provision.auth.provider.oauth2.user-info-uri=userInfo
-provision.auth.provider.basic-auth.activate-beside-oauth2=utest
+provision.auth.basic-auth.enabled=utest
 
 logging.level.root=WARN
 logging.level.org.springframework=INFO


### PR DESCRIPTION
fixes #504 
add this property `provision.auth.provider.basic-auth.activate-beside-crowd=true` to your application.properties to enable basic auth for crowd auth profile.