### PR TITLE
delete components now removes the quickstarters also from the storage

### DIFF
--- a/src/main/java/org/opendevstack/provision/controller/ProjectApiController.java
+++ b/src/main/java/org/opendevstack/provision/controller/ProjectApiController.java
@@ -891,7 +891,9 @@ public class ProjectApiController {
               project.projectKey, leftovers);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
     } else {
-      return ResponseEntity.ok().build();
+      project.removeQuickstartersFromProject(deletableComponents.getQuickstarters());
+      this.directStorage.updateStoredProject(project);
+      return ResponseEntity.ok(project);
     }
   }
 

--- a/src/main/java/org/opendevstack/provision/model/OpenProjectData.java
+++ b/src/main/java/org/opendevstack/provision/model/OpenProjectData.java
@@ -113,6 +113,17 @@ public class OpenProjectData {
     return quickstarters == null ? Collections.emptyList() : quickstarters;
   }
 
+  public List<Map<String, String>> removeQuickstartersFromProject(
+      List<Map<String, String>> quickstartersToRemove) {
+    if (quickstartersToRemove == null) {
+      return this.quickstarters;
+    }
+    for (Map<String, String> quickstarter : quickstartersToRemove) {
+      quickstarters.remove(quickstarter);
+    }
+    return quickstarters;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {

--- a/src/test/java/org/opendevstack/provision/controller/E2EProjectAPIControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/E2EProjectAPIControllerTest.java
@@ -681,7 +681,7 @@ public class E2EProjectAPIControllerTest {
 
     mockExecuteAdminJob("ods", "delete-projects", "testp");
 
-    // verify project is there .. 
+    // verify project is there ..
     mockMvc
         .perform(
             get("/api/v2/project/" + toClean.projectKey)
@@ -701,16 +701,16 @@ public class E2EProjectAPIControllerTest {
                 .accept(MediaType.APPLICATION_JSON))
         .andDo(MockMvcResultHandlers.print())
         .andExpect(MockMvcResultMatchers.status().isOk());
-    
-    // verify project really deleted - and not found 
+
+    // verify project really deleted - and not found
     mockMvc
-      .perform(
-          get("/api/v2/project/" + toClean.projectKey)
-              .contentType(MediaType.APPLICATION_JSON)
-              .with(httpBasic(testAdminUsername, VALID_CREDENTIAL))
-              .accept(MediaType.APPLICATION_JSON))
-      .andDo(MockMvcResultHandlers.print())
-      .andExpect(MockMvcResultMatchers.status().isNotFound());
+        .perform(
+            get("/api/v2/project/" + toClean.projectKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic(testAdminUsername, VALID_CREDENTIAL))
+                .accept(MediaType.APPLICATION_JSON))
+        .andDo(MockMvcResultHandlers.print())
+        .andExpect(MockMvcResultMatchers.status().isNotFound());
   }
 
   /** Test positive new quickstarter and delete single component afterwards */
@@ -732,8 +732,13 @@ public class E2EProjectAPIControllerTest {
     String prefix = createdProjectIncludingQuickstarters.quickstarters.get(0).get("component_id");
 
     int currentQuickstarterSize = toClean.quickstarters.size();
-    e2eLogger.info("4 delete, current Quickstarters: " + currentQuickstarterSize + " project: " + 
-        toClean.projectKey + "\n" + toClean.quickstarters);
+    e2eLogger.info(
+        "4 delete, current Quickstarters: "
+            + currentQuickstarterSize
+            + " project: "
+            + toClean.projectKey
+            + "\n"
+            + toClean.quickstarters);
 
     mockExecuteDeleteComponentAdminJob(
         "testp-cd",
@@ -743,47 +748,47 @@ public class E2EProjectAPIControllerTest {
 
     // delete single component (via
     // org.opendevstack.provision.controller.ProjectApiController.deleteComponents)
-    MvcResult resultProjectGetResponse = mockMvc
-        .perform(
-            delete("/api/v2/project/")
-                .content(ProjectApiControllerTest.asJsonString(toClean))
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(httpBasic(testAdminUsername, VALID_CREDENTIAL))
-                .accept(MediaType.APPLICATION_JSON))
-        .andDo(MockMvcResultHandlers.print())
-        .andExpect(MockMvcResultMatchers.status().isOk())
-        .andReturn();
+    MvcResult resultProjectGetResponse =
+        mockMvc
+            .perform(
+                delete("/api/v2/project/")
+                    .content(ProjectApiControllerTest.asJsonString(toClean))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(httpBasic(testAdminUsername, VALID_CREDENTIAL))
+                    .accept(MediaType.APPLICATION_JSON))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn();
 
-    e2eLogger.info("Delete response: " +
-        resultProjectGetResponse.getResponse().getContentAsString());
+    e2eLogger.info(
+        "Delete response: " + resultProjectGetResponse.getResponse().getContentAsString());
 
     OpenProjectData resultProject =
         new ObjectMapper()
             .readValue(
-                resultProjectGetResponse.getResponse().getContentAsString(),
-                OpenProjectData.class);
+                resultProjectGetResponse.getResponse().getContentAsString(), OpenProjectData.class);
 
-    assertTrue(resultProject.getQuickstarters().size() == (currentQuickstarterSize -1));
+    assertTrue(resultProject.getQuickstarters().size() == (currentQuickstarterSize - 1));
 
     // retrieve the project thru the get endpoint - to ensure we have the right data stored
-    resultProjectGetResponse = mockMvc
-        .perform(
-            get("/api/v2/project/" + toClean.projectKey)
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(httpBasic(testAdminUsername, VALID_CREDENTIAL))
-                .accept(MediaType.APPLICATION_JSON))
-        .andDo(MockMvcResultHandlers.print())
-        .andExpect(MockMvcResultMatchers.status().isOk())
-        .andReturn();
+    resultProjectGetResponse =
+        mockMvc
+            .perform(
+                get("/api/v2/project/" + toClean.projectKey)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(httpBasic(testAdminUsername, VALID_CREDENTIAL))
+                    .accept(MediaType.APPLICATION_JSON))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn();
 
     resultProject =
         new ObjectMapper()
             .readValue(
-                resultProjectGetResponse.getResponse().getContentAsString(),
-                OpenProjectData.class);
+                resultProjectGetResponse.getResponse().getContentAsString(), OpenProjectData.class);
 
     assertEquals(toClean.projectKey, resultProject.projectKey);
-    assertTrue(resultProject.getQuickstarters().size() == (currentQuickstarterSize -1));
+    assertTrue(resultProject.getQuickstarters().size() == (currentQuickstarterSize - 1));
     assertTrue(resultProject.getQuickstarters().isEmpty());
   }
 

--- a/src/test/java/org/opendevstack/provision/controller/E2EProjectAPIControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/E2EProjectAPIControllerTest.java
@@ -680,9 +680,19 @@ public class E2EProjectAPIControllerTest {
     toClean.quickstarters = createdProjectIncludingQuickstarters.quickstarters;
 
     mockExecuteAdminJob("ods", "delete-projects", "testp");
+
+    // verify project is there .. 
+    mockMvc
+        .perform(
+            get("/api/v2/project/" + toClean.projectKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic(testAdminUsername, VALID_CREDENTIAL))
+                .accept(MediaType.APPLICATION_JSON))
+        .andDo(MockMvcResultHandlers.print())
+        .andExpect(MockMvcResultMatchers.status().isOk());
+
     // delete whole projects (-cd, -dev and -test), calls
     // org.opendevstack.provision.controller.ProjectApiController.deleteProject
-
     mockMvc
         .perform(
             delete("/api/v2/project/" + toClean.projectKey)
@@ -691,6 +701,16 @@ public class E2EProjectAPIControllerTest {
                 .accept(MediaType.APPLICATION_JSON))
         .andDo(MockMvcResultHandlers.print())
         .andExpect(MockMvcResultMatchers.status().isOk());
+    
+    // verify project really deleted - and not found 
+    mockMvc
+      .perform(
+          get("/api/v2/project/" + toClean.projectKey)
+              .contentType(MediaType.APPLICATION_JSON)
+              .with(httpBasic(testAdminUsername, VALID_CREDENTIAL))
+              .accept(MediaType.APPLICATION_JSON))
+      .andDo(MockMvcResultHandlers.print())
+      .andExpect(MockMvcResultMatchers.status().isNotFound());
   }
 
   /** Test positive new quickstarter and delete single component afterwards */
@@ -711,6 +731,10 @@ public class E2EProjectAPIControllerTest {
 
     String prefix = createdProjectIncludingQuickstarters.quickstarters.get(0).get("component_id");
 
+    int currentQuickstarterSize = toClean.quickstarters.size();
+    e2eLogger.info("4 delete, current Quickstarters: " + currentQuickstarterSize + " project: " + 
+        toClean.projectKey + "\n" + toClean.quickstarters);
+
     mockExecuteDeleteComponentAdminJob(
         "testp-cd",
         "delete-components",
@@ -719,7 +743,7 @@ public class E2EProjectAPIControllerTest {
 
     // delete single component (via
     // org.opendevstack.provision.controller.ProjectApiController.deleteComponents)
-    mockMvc
+    MvcResult resultProjectGetResponse = mockMvc
         .perform(
             delete("/api/v2/project/")
                 .content(ProjectApiControllerTest.asJsonString(toClean))
@@ -727,7 +751,40 @@ public class E2EProjectAPIControllerTest {
                 .with(httpBasic(testAdminUsername, VALID_CREDENTIAL))
                 .accept(MediaType.APPLICATION_JSON))
         .andDo(MockMvcResultHandlers.print())
-        .andExpect(MockMvcResultMatchers.status().isOk());
+        .andExpect(MockMvcResultMatchers.status().isOk())
+        .andReturn();
+
+    e2eLogger.info("Delete response: " +
+        resultProjectGetResponse.getResponse().getContentAsString());
+
+    OpenProjectData resultProject =
+        new ObjectMapper()
+            .readValue(
+                resultProjectGetResponse.getResponse().getContentAsString(),
+                OpenProjectData.class);
+
+    assertTrue(resultProject.getQuickstarters().size() == (currentQuickstarterSize -1));
+
+    // retrieve the project thru the get endpoint - to ensure we have the right data stored
+    resultProjectGetResponse = mockMvc
+        .perform(
+            get("/api/v2/project/" + toClean.projectKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic(testAdminUsername, VALID_CREDENTIAL))
+                .accept(MediaType.APPLICATION_JSON))
+        .andDo(MockMvcResultHandlers.print())
+        .andExpect(MockMvcResultMatchers.status().isOk())
+        .andReturn();
+
+    resultProject =
+        new ObjectMapper()
+            .readValue(
+                resultProjectGetResponse.getResponse().getContentAsString(),
+                OpenProjectData.class);
+
+    assertEquals(toClean.projectKey, resultProject.projectKey);
+    assertTrue(resultProject.getQuickstarters().size() == (currentQuickstarterSize -1));
+    assertTrue(resultProject.getQuickstarters().isEmpty());
   }
 
   private void mockExecuteAdminJob(String namespace, String jobName, String prefix)


### PR DESCRIPTION
fixes #547 

very surgical fix - remove the quickstarters - and update the storage. 
Tests cover this now - including checking the response, as well as retrieving the project and verifying the quickstarters are not there anymore.