### PR TITLE
Pass ODS_BITBUCKET_PROJECT to jobs

### DIFF
--- a/src/main/java/org/opendevstack/provision/services/JenkinsPipelineAdapter.java
+++ b/src/main/java/org/opendevstack/provision/services/JenkinsPipelineAdapter.java
@@ -195,6 +195,7 @@ public class JenkinsPipelineAdapter extends BaseServiceAdapter implements IJobEx
         options.put(PROJECT_ID_KEY, project.projectKey.toLowerCase());
         options.put("PACKAGE_NAME", packageName);
         options.put("ODS_NAMESPACE", odsNamespace);
+        options.put("ODS_BITBUCKET_PROJECT", bitbucketOdsProject);
         options.put("ODS_IMAGE_TAG", odsImageTag);
         options.put("ODS_GIT_REF", odsGitRef);
 
@@ -285,6 +286,7 @@ public class JenkinsPipelineAdapter extends BaseServiceAdapter implements IJobEx
       }
 
       options.put("ODS_NAMESPACE", odsNamespace);
+      options.put("ODS_BITBUCKET_PROJECT", bitbucketOdsProject);
       options.put("ODS_IMAGE_TAG", odsImageTag);
       options.put("ODS_GIT_REF", odsGitRef);
       options.put(OPTION_KEY_GIT_SERVER_URL, bitbucketUri);
@@ -588,6 +590,7 @@ public class JenkinsPipelineAdapter extends BaseServiceAdapter implements IJobEx
     options.put(PROJECT_ID_KEY, projectId);
     options.put(OpenProjectData.COMPONENT_ID_KEY, componentId);
     options.put("ODS_NAMESPACE", odsNamespace);
+    options.put("ODS_BITBUCKET_PROJECT", bitbucketOdsProject);
     options.put("ODS_IMAGE_TAG", odsImageTag);
     options.put("ODS_GIT_REF", odsGitRef);
     return options;

--- a/src/test/java/org/opendevstack/provision/services/JenkinsPipelineAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/JenkinsPipelineAdapterTest.java
@@ -84,6 +84,7 @@ public class JenkinsPipelineAdapterTest extends AbstractBaseServiceAdapterTest {
     jenkinsPipelineAdapter.userName = "maier";
     jenkinsPipelineAdapter.generalCdUser = "cd_user";
     jenkinsPipelineAdapter.odsNamespace = "ods";
+    jenkinsPipelineAdapter.bitbucketOdsProject = "opendevstack";
     jenkinsPipelineAdapter.odsImageTag = "latest";
     jenkinsPipelineAdapter.odsGitRef = "master";
     jenkinsPipelineAdapter.init();
@@ -289,6 +290,7 @@ public class JenkinsPipelineAdapterTest extends AbstractBaseServiceAdapterTest {
             new Option("PROJECT_ID", projectData.projectKey),
             new Option("PROJECT_ADMIN", jenkinsPipelineAdapter.userName),
             new Option("ODS_NAMESPACE", jenkinsPipelineAdapter.odsNamespace),
+            new Option("ODS_BITBUCKET_PROJECT", jenkinsPipelineAdapter.bitbucketOdsProject),
             new Option("ODS_IMAGE_TAG", jenkinsPipelineAdapter.odsImageTag),
             new Option("ODS_GIT_REF", jenkinsPipelineAdapter.odsGitRef));
 
@@ -392,6 +394,8 @@ public class JenkinsPipelineAdapterTest extends AbstractBaseServiceAdapterTest {
         .isEqualTo(jenkinsPipelineAdapter.bitbucketUri);
     Assertions.assertThat(actualBody.getOptionValue("ODS_NAMESPACE"))
         .isEqualTo(jenkinsPipelineAdapter.odsNamespace);
+    Assertions.assertThat(actualBody.getOptionValue("ODS_BITBUCKET_PROJECT"))
+        .isEqualTo(jenkinsPipelineAdapter.bitbucketOdsProject);
     Assertions.assertThat(actualBody.getOptionValue("ODS_IMAGE_TAG"))
         .isEqualTo(jenkinsPipelineAdapter.odsImageTag);
     Assertions.assertThat(actualBody.getOptionValue("ODS_GIT_REF"))


### PR DESCRIPTION
Otherwise the `ALLOWED_EXTERNAL_PROJECTS` value of the webhook proxy is not set correctly for Bitbucket projects other than `OPENDEVSTACK`, which prevents components from being provisioned correctly.