### PR TITLE
feature/gh 404 parameterise jira project templates

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,4 +20,4 @@ ENTRYPOINT ["entrypoint.sh"]
 # which are defined in classpath:/application.properties
 # for details refert to Spring boot documention:
 # https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config
-CMD ["java", "-jar", "app.jar", "--spring.config.additional-location=/quickstarters/quickstarters.properties,/config/*/"]
+CMD ["java", "-jar", "app.jar", "--spring.config.additional-location=/quickstarters/quickstarters.properties,/jira-project-types/additional-templates.properties,/config/*/"]


### PR DESCRIPTION
fixes partially #404
Additionally, to complete this feature we need to change in ods-core the provisioning app configuration defined in cm.yml and dc.yml -> see opendevstack/ods-core#778