### PR TITLE
replaces docker image from openjdk11:ubi-jre

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:ubi-minimal-jre
+FROM adoptopenjdk/openjdk11:ubi-jre
  
 COPY files/entrypoint.sh /usr/local/bin/
 COPY app.jar app.jar


### PR DESCRIPTION
fixes #589 