### PR TITLE
Make cdUser field mandatory

### DIFF
--- a/client/src/app/domain/project.ts
+++ b/client/src/app/domain/project.ts
@@ -9,7 +9,7 @@ export interface ProjectData {
   projectKey: string;
   description?: string;
   webhookProxySecret?: string;
-  cdUser?: string;
+  cdUser: string;
   quickstarters?: ProjectQuickstarterComponentsData[];
   bugtrackerSpace: boolean;
   platformRuntime: boolean;

--- a/client/src/app/modules/app-form/config/validation.json
+++ b/client/src/app/modules/app-form/config/validation.json
@@ -2,17 +2,15 @@
   "project": {
     "name": {
       "regex": "([a-zA-Z][a-zA-Z_0-9]+)",
-      "errorMessages": [
-        "Please enter 2-80 characters",
-        "Please use numbers, letters and underscore"
-      ]
+      "errorMessages": ["Please enter 2-80 characters", "Please use numbers, letters and underscore"]
     },
     "key": {
       "regex": "([a-zA-Z][a-zA-Z_0-9]+)",
-      "errorMessages": [
-        "Please enter 2-10 characters",
-        "Please use numbers, letters and underscore"
-      ]
+      "errorMessages": ["Please enter 2-10 characters", "Please use numbers, letters and underscore"]
+    },
+    "cdUser": {
+      "regex": "([a-zA-Z][a-zA-Z_0-9]+)",
+      "errorMessages": ["Please enter at least 2 characters", "Please use numbers, letters and underscore"]
     }
   },
   "quickstarters": {

--- a/client/src/app/modules/new-project/components/new-project.component.html
+++ b/client/src/app/modules/new-project/components/new-project.component.html
@@ -98,18 +98,31 @@
                     placeholder="Project specific CD user"
                     formControlName="cdUser"
                     appRemoveWhitespaces
+                    required
                   />
                 </mat-form-field>
                 <mat-icon
                   svgIcon="information"
                   aria-hidden="false"
-                  aria-label="If you use a project specific CD user, the user has to exist in your identity management and has to be able to access Bitbucket.
+                  aria-label="The CD user has to exist in your identity management and has to be able to access Bitbucket.
                     After project creation you will have to change the CD user password in the OpenShift webconsole of the created CD project."
-                  matTooltip="If you use a project specific CD user, the user has to exist in your identity management and has to be able to access Bitbucket.
+                  matTooltip="The CD user has to exist in your identity management and has to be able to access Bitbucket.
                     After project creation you will have to change the CD user password in the OpenShift webconsole of the created CD project."
                   matTooltipClass="formfield__tooltip"
                 ></mat-icon>
               </div>
+              <mat-error
+                class="formfield__error"
+                *ngIf="hasErrorByType(form.get('cdUser'), 'required')">
+                Project specific CD user is required
+              </mat-error>
+              <mat-error
+                class="formfield__error"
+                *ngIf="hasErrorByType(form.get('cdUser'), 'pattern')">
+                <ul>
+                  <li *ngFor="let message of validationConfig.project.cdUser.errorMessages">{{ message }}</li>
+                </ul>
+              </mat-error>
             </div>
             <div class="col">
               <mat-form-field>

--- a/client/src/app/modules/new-project/components/new-project.component.ts
+++ b/client/src/app/modules/new-project/components/new-project.component.ts
@@ -105,7 +105,7 @@ export class NewProjectComponent extends FormBaseComponent implements OnInit, On
     this.form = this.formBuilder.group({
       name: ['', [Validators.required, Validators.pattern(this.validationConfig.project.name.regex)]],
       key: ['', [Validators.required, Validators.pattern(this.validationConfig.project.key.regex)]],
-      cdUser: null,
+      cdUser: ['', [Validators.required, Validators.pattern(this.validationConfig.project.cdUser.regex)]],
       template: [null, Validators.required],
       description: null,
       optInODS: null,


### PR DESCRIPTION
Fixes #577 

Although the cd User doesn't seem to be regex-checked in the backend I thought it makes sense at least to do so in the frontend. I used this one: `([a-zA-Z][a-zA-Z_0-9]+)`

Based on that I think it makes sense to re-evaluate the regex rules, e.g. do we need more where currently are no checks and less or more strict ones.