### PR TITLE
Update spring boot version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ gradle.properties
 /src/main/resources/__application.properties
 /src/main/resources/application-oauth2private.properties
 /src/main/resources/application-testods.properties
+/src/main/resources/application-local.properties
 
 /src/main/resources/history-local/
 

--- a/build.gradle
+++ b/build.gradle
@@ -194,4 +194,4 @@ task yarnBuild(type:Exec) {
     commandLine 'yarn', 'build'
 }
 
-bootRun.dependsOn yarnBuild
+//bootRun.dependsOn yarnBuild

--- a/build.gradle
+++ b/build.gradle
@@ -80,8 +80,8 @@ dependencies {
     implementation 'org.springframework.security:spring-security-oauth2-core'
     implementation 'org.springframework.security:spring-security-oauth2-client'
     implementation 'org.springframework.security:spring-security-oauth2-jose'
-    //implementation 'org.springframework.security:spring-security-jwt:1.1.0.RELEASE'
-    implementation 'org.springframework.security.oauth:spring-security-oauth2:2.5.0.RELEASE'
+    implementation 'org.springframework.security:spring-security-jwt:1.1.0.RELEASE'
+    implementation 'org.springframework.security.oauth:spring-security-oauth2:2.4.0.RELEASE'
 
     implementation(group: 'com.openshift', name: 'openshift-restclient-java', version: '9.0.0.Final') {
         exclude(group: 'org.slf4j', module: 'slf4j-api:')
@@ -107,7 +107,7 @@ dependencies {
 
     implementation group: 'commons-httpclient', name: 'commons-httpclient', version: '3.1'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.10.0.pr3'
-    //implementation group: 'joda-time', name: 'joda-time', version: '2.10.4'
+    implementation group: 'joda-time', name: 'joda-time', version: '2.10.4'
     implementation(group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final')
     implementation(group: 'com.atlassian.security', name: 'atlassian-cookie-tools', version: '3.2.11')
     implementation(group: 'com.atlassian.crowd', name: 'crowd-integration-springsecurity', version: '1000.82.0') {
@@ -194,4 +194,4 @@ task yarnBuild(type:Exec) {
     commandLine 'yarn', 'build'
 }
 
-//bootRun.dependsOn yarnBuild
+bootRun.dependsOn yarnBuild

--- a/build.gradle
+++ b/build.gradle
@@ -1,98 +1,54 @@
 buildscript {
-
     ext {
-        springBootVersion = '2.2.4.RELEASE'
-        // fix for not set system variable
+        // set gradle properties regarding nexus
         nexus_url = project.findProperty('nexus_url') ?: System.getenv('NEXUS_HOST')
         nexus_user = project.findProperty('nexus_user') ?: System.getenv('NEXUS_USERNAME')
         nexus_pw = project.findProperty('nexus_pw') ?: System.getenv('NEXUS_PASSWORD')
-        no_nexus = (project.findProperty('no_nexus') ?: System.getenv('NO_NEXUS') ?: false).toBoolean()
-
-
-    }
-
-    repositories {
-        if (no_nexus) {
-            println("using repositories 'jcenter' and 'mavenCentral'")
-            jcenter()
-            mavenCentral()
-        } else {
-            println("using nexus repositories")
-            if (!nexus_url) {
-                throw new GradleException('Nexus URL not specified!')
-            }
-            maven() {
-                url "${nexus_url}/repository/jcenter/"
-                credentials() {
-                    username = "${nexus_user}"
-                    password = "${nexus_pw}"
-                }
-            }
-            maven() {
-                url "${nexus_url}/repository/maven-public/"
-                credentials() {
-                    username = "${nexus_user}"
-                    password = "${nexus_pw}"
-                }
-            }
-            maven() {
-                url "${nexus_url}/repository/atlassian_public/"
-                credentials {
-                    username = "${nexus_user}"
-                    password = "${nexus_pw}"
-                }
-            }
+        no_nexus = project.findProperty('no_nexus') ?: System.getenv('NO_NEXUS') ?: false
+        if (!no_nexus && (nexus_url == null || nexus_user == null || nexus_pw == null)) {
+            throw new GradleException("property 'no_nexus' is set to false, but neither " +
+                "'nexus_url', 'nexus_user' nor 'nexus_pw' is configured. You can do so " +
+                "by e.g. creating a gradle.properties file in your 'GRADLE_USER_HOME' " +
+                "(by default '~/.gradle') folder and setting the nexus properties there.")
         }
-    }
-    dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
-        classpath("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.8")
+        nexusFolderReleases = project.findProperty('nexus_folder_releases')
+            ?: System.getenv('NEXUS_FOLDER_RELEASES') ?: "maven-releases"
+        nexusFolderSnapshots = project.findProperty('nexus_folder_snapshots')
+            ?: System.getenv('NEXUS_FOLDER_SNAPSHOTS') ?: "maven-snapshots"
     }
 }
 
 plugins {
-    id 'org.springframework.boot' version '2.2.4.RELEASE'
+    id 'org.springframework.boot' version '2.4.0'
+    id 'io.spring.dependency-management' version '1.0.10.RELEASE'
     id 'java'
-    id 'eclipse'
     id 'maven-publish'
     id 'jacoco'
     id 'org.sonarqube' version "3.0"
     id "com.diffplug.spotless" version "5.8.2"
 }
 
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-
 group = 'prov'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = 1.11
 
 repositories {
-    if (no_nexus) {
-        jcenter()
-        mavenCentral()
+    if (!no_nexus) {
+        def nexusMaven = { repoUrl ->
+            maven {
+                credentials {
+                    username = "${nexus_user}"
+                    password = "${nexus_pw}"
+                }
+                url repoUrl
+            }
+        }
+        nexusMaven("${nexus_url}/repository/jcenter/")
+        nexusMaven("${nexus_url}/repository/maven-public/")
+        nexusMaven("${nexus_url}/repository/atlassian_public/")
     } else {
-        maven() {
-            url "${nexus_url}/repository/jcenter/"
-            credentials() {
-                username = "${nexus_user}"
-                password = "${nexus_pw}"
-            }
-        }
-        maven() {
-            url "${nexus_url}/repository/maven-public/"
-            credentials() {
-                username = "${nexus_user}"
-                password = "${nexus_pw}"
-            }
-        }
-        maven() {
-            url "${nexus_url}/repository/atlassian_public/"
-            credentials {
-                username = "${nexus_user}"
-                password = "${nexus_pw}"
-            }
-        }
+        mavenCentral()
+        jcenter()
     }
 }
 
@@ -124,8 +80,8 @@ dependencies {
     implementation 'org.springframework.security:spring-security-oauth2-core'
     implementation 'org.springframework.security:spring-security-oauth2-client'
     implementation 'org.springframework.security:spring-security-oauth2-jose'
-    implementation 'org.springframework.security:spring-security-jwt:1.1.0.RELEASE'
-    implementation 'org.springframework.security.oauth:spring-security-oauth2:2.4.0.RELEASE'
+    //implementation 'org.springframework.security:spring-security-jwt:1.1.0.RELEASE'
+    implementation 'org.springframework.security.oauth:spring-security-oauth2:2.5.0.RELEASE'
 
     implementation(group: 'com.openshift', name: 'openshift-restclient-java', version: '9.0.0.Final') {
         exclude(group: 'org.slf4j', module: 'slf4j-api:')
@@ -151,7 +107,7 @@ dependencies {
 
     implementation group: 'commons-httpclient', name: 'commons-httpclient', version: '3.1'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.10.0.pr3'
-    implementation group: 'joda-time', name: 'joda-time', version: '2.10.4'
+    //implementation group: 'joda-time', name: 'joda-time', version: '2.10.4'
     implementation(group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final')
     implementation(group: 'com.atlassian.security', name: 'atlassian-cookie-tools', version: '3.2.11')
     implementation(group: 'com.atlassian.crowd', name: 'crowd-integration-springsecurity', version: '1000.82.0') {
@@ -191,6 +147,7 @@ bootJar {
 
 test {
     finalizedBy jacocoTestReport
+    useJUnitPlatform()
 }
 
 bootRun {
@@ -216,6 +173,7 @@ jacocoTestReport {
     }
 }
 
+// run with ./gradlew spotlessApply.
 spotless {
     java {
         googleJavaFormat('1.9')

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,4 +20,4 @@ ENTRYPOINT ["entrypoint.sh"]
 # which are defined in classpath:/application.properties
 # for details refert to Spring boot documention:
 # https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config
-CMD ["java", "-jar", "app.jar", "--spring.config.additional-location=/quickstarters/quickstarters.properties,/jira-project-types/additional-templates.properties"]
+CMD ["java", "-jar", "app.jar", "--spring.config.additional-location=/quickstarters/quickstarters.properties,optional:file:/jira-project-types/additional-templates.properties"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,4 +20,4 @@ ENTRYPOINT ["entrypoint.sh"]
 # which are defined in classpath:/application.properties
 # for details refert to Spring boot documention:
 # https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config
-CMD ["java", "-jar", "app.jar", "--spring.config.additional-location=/quickstarters/quickstarters.properties,/jira-project-types/additional-templates.properties,/config/*/"]
+CMD ["java", "-jar", "app.jar", "--spring.config.additional-location=/quickstarters/quickstarters.properties,/jira-project-types/additional-templates.properties"]

--- a/src/test/java/org/opendevstack/provision/SpringMvcProvisioningAppApplicationTests.java
+++ b/src/test/java/org/opendevstack/provision/SpringMvcProvisioningAppApplicationTests.java
@@ -14,16 +14,12 @@
 
 package org.opendevstack.provision;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @DirtiesContext
 @ActiveProfiles("utest")
 public class SpringMvcProvisioningAppApplicationTests {

--- a/src/test/java/org/opendevstack/provision/authentication/ProvAppHttpSessionListenerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/ProvAppHttpSessionListenerTest.java
@@ -1,5 +1,6 @@
 package org.opendevstack.provision.authentication;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.atlassian.crowd.integration.springsecurity.user.CrowdUserDetails;
@@ -9,9 +10,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpSessionEvent;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -19,9 +19,9 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.test.context.TestSecurityContextHolder;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class ProvAppHttpSessionListenerTest {
 
   @MockBean private HttpSessionEvent sessionEvent;
@@ -50,7 +50,7 @@ public class ProvAppHttpSessionListenerTest {
     ProvAppHttpSessionListener provAppHttpSessionListener =
         new ProvAppHttpSessionListener(
             auth -> {
-              Assert.assertEquals(authentication, auth);
+              assertEquals(authentication, auth);
               latch.countDown();
               return "username";
             });
@@ -58,8 +58,8 @@ public class ProvAppHttpSessionListenerTest {
     provAppHttpSessionListener.sessionDestroyed(sessionEvent);
 
     boolean await = latch.await(100, TimeUnit.MILLISECONDS);
-    Assert.assertTrue(await);
-    Assert.assertEquals(0, latch.getCount());
+    assertTrue(await);
+    assertEquals(0, latch.getCount());
   }
 
   @Test
@@ -84,7 +84,7 @@ public class ProvAppHttpSessionListenerTest {
         ProvAppHttpSessionListener.createUsernameProvider();
 
     // if authentication == null no exception is raised
-    Assert.assertNull(usernameProvider.apply(null));
+    assertNull(usernameProvider.apply(null));
 
     {
       OAuth2AuthenticationToken auth = mock(OAuth2AuthenticationToken.class);
@@ -93,7 +93,7 @@ public class ProvAppHttpSessionListenerTest {
       when(oidcUser.getEmail()).thenReturn(username);
 
       // authentication instance of OAuth2AuthenticationToken
-      Assert.assertEquals(username, usernameProvider.apply(auth));
+      assertEquals(username, usernameProvider.apply(auth));
     }
 
     {
@@ -103,12 +103,12 @@ public class ProvAppHttpSessionListenerTest {
       CrowdUserDetails userDetails = mock(CrowdUserDetails.class);
       when(passwordAuthenticationToken.getPrincipal()).thenReturn(userDetails);
       when(userDetails.getUsername()).thenReturn(username);
-      Assert.assertEquals(username, usernameProvider.apply(passwordAuthenticationToken));
+      assertEquals(username, usernameProvider.apply(passwordAuthenticationToken));
     }
 
     {
       // authentication instance of something else
-      Assert.assertNull(usernameProvider.apply(mock(Authentication.class)));
+      assertNull(usernameProvider.apply(mock(Authentication.class)));
     }
   }
 }

--- a/src/test/java/org/opendevstack/provision/authentication/SimpleCachingGroupMembershipManagerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/SimpleCachingGroupMembershipManagerTest.java
@@ -1,8 +1,8 @@
 package org.opendevstack.provision.authentication;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import com.atlassian.crowd.integration.soap.SOAPPrincipal;
 import com.atlassian.crowd.integration.springsecurity.user.CrowdUserDetails;
@@ -11,20 +11,15 @@ import com.atlassian.crowd.service.GroupManager;
 import com.atlassian.crowd.service.UserManager;
 import com.atlassian.crowd.service.cache.BasicCache;
 import com.atlassian.crowd.service.soap.client.SecurityServerClient;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.opendevstack.provision.SpringBoot;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @DirtiesContext
 /** Testclass for the simple caching manager */
 @ActiveProfiles("crowd")

--- a/src/test/java/org/opendevstack/provision/authentication/crowd/CrowdAuthenticationManagerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/crowd/CrowdAuthenticationManagerTest.java
@@ -14,10 +14,7 @@
 
 package org.opendevstack.provision.authentication.crowd;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.atlassian.crowd.embedded.api.PasswordCredential;
 import com.atlassian.crowd.exception.InvalidAuthenticationException;
@@ -30,22 +27,17 @@ import com.atlassian.crowd.service.soap.client.SoapClientProperties;
 import com.atlassian.crowd.service.soap.client.SoapClientPropertiesImpl;
 import java.rmi.RemoteException;
 import java.util.Properties;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.opendevstack.provision.SpringBoot;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @DirtiesContext
 @WithMockUser(
     username = CrowdAuthenticationManagerTest.USER,
@@ -65,7 +57,7 @@ public class CrowdAuthenticationManagerTest {
 
   @Mock private SecurityServerClient securityServerClient;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     String token = TOKEN;
     ValidationFactor[] factors = new ValidationFactor[0];
@@ -127,23 +119,24 @@ public class CrowdAuthenticationManagerTest {
     assertTrue(manager.isAuthenticated("", new ValidationFactor[0]));
   }
 
-  @Test(expected = RemoteException.class)
-  public void invalidateWithRemoteException() throws Exception {
-    manager.invalidate("remote");
-  }
-
-  @Test(expected = InvalidAuthorizationTokenException.class)
-  public void invalidateWithInvalidAuthorizationTokenException() throws Exception {
-    manager.invalidate("invalid_token");
-  }
-
-  @Test(expected = InvalidAuthenticationException.class)
-  public void invalidateWithInvalidAuthenticationException() throws Exception {
-    manager.invalidate("invalid_auth");
+  @Test
+  public void invalidateWithRemoteException() {
+    assertThrows(RemoteException.class, () -> manager.invalidate("remote"));
   }
 
   @Test
-  public void getSecurityServerClient() throws Exception {
+  public void invalidateWithInvalidAuthorizationTokenException() {
+    assertThrows(
+        InvalidAuthorizationTokenException.class, () -> manager.invalidate("invalid_token"));
+  }
+
+  @Test
+  public void invalidateWithInvalidAuthenticationException() {
+    assertThrows(InvalidAuthenticationException.class, () -> manager.invalidate("invalid_auth"));
+  }
+
+  @Test
+  public void getSecurityServerClient() {
     assertNotNull(manager.getSecurityServerClient());
     assertTrue((manager.getSecurityServerClient() instanceof SecurityServerClient));
   }

--- a/src/test/java/org/opendevstack/provision/authentication/crowd/ProvAppSimpleCachingGroupMembershipManagerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/crowd/ProvAppSimpleCachingGroupMembershipManagerTest.java
@@ -14,7 +14,7 @@
 
 package org.opendevstack.provision.authentication.crowd;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -27,14 +27,12 @@ import com.atlassian.crowd.service.cache.BasicCache;
 import com.atlassian.crowd.service.soap.client.SecurityServerClient;
 import java.rmi.RemoteException;
 import java.util.List;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
-@DirtiesContext
+@ExtendWith(SpringExtension.class)
 public class ProvAppSimpleCachingGroupMembershipManagerTest {
 
   @MockBean private SecurityServerClient securityServerClient;

--- a/src/test/java/org/opendevstack/provision/authentication/filter/SSOAuthProcessingFilterBasicAuthHandlerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/filter/SSOAuthProcessingFilterBasicAuthHandlerTest.java
@@ -13,21 +13,19 @@
  */
 package org.opendevstack.provision.authentication.filter;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.opendevstack.provision.authentication.TestAuthentication;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.TestSecurityContextHolder;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
-@DirtiesContext
+@ExtendWith(SpringExtension.class)
 public class SSOAuthProcessingFilterBasicAuthHandlerTest {
 
   @MockBean private HttpServletRequest request;

--- a/src/test/java/org/opendevstack/provision/authentication/filter/SSOAuthProcessingFilterTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/filter/SSOAuthProcessingFilterTest.java
@@ -14,8 +14,8 @@
 
 package org.opendevstack.provision.authentication.filter;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -23,15 +23,13 @@ import com.atlassian.crowd.integration.http.HttpAuthenticator;
 import com.atlassian.crowd.integration.springsecurity.CrowdSSOAuthenticationToken;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
-@DirtiesContext
+@ExtendWith(SpringExtension.class)
 public class SSOAuthProcessingFilterTest {
 
   @MockBean private HttpAuthenticator httpAuthenticator;
@@ -44,7 +42,7 @@ public class SSOAuthProcessingFilterTest {
 
   private SSOAuthProcessingFilter filter = new SSOAuthProcessingFilter();
 
-  @Before
+  @BeforeEach
   public void setup() {
     filter.setBasicAuthHandlerStrategy(basicAuthStrategy);
     filter.setHttpAuthenticator(httpAuthenticator);

--- a/src/test/java/org/opendevstack/provision/authentication/oauth2/MethodSecurityConfigurationTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/oauth2/MethodSecurityConfigurationTest.java
@@ -13,19 +13,16 @@
  */
 package org.opendevstack.provision.authentication.oauth2;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opendevstack.provision.SpringBoot;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 import org.opendevstack.provision.authentication.authorization.MethodSecurityConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @DirtiesContext
 @ActiveProfiles("utest")
 public class MethodSecurityConfigurationTest {
@@ -35,6 +32,6 @@ public class MethodSecurityConfigurationTest {
   @Test
   public void opendevstackRoles() {
     // 2 roles are expected: user and administrator!
-    Assert.assertEquals(2, methodSecurityConfiguration.opendevstackRoles().size());
+    assertEquals(2, methodSecurityConfiguration.opendevstackRoles().size());
   }
 }

--- a/src/test/java/org/opendevstack/provision/authentication/oauth2/Oauth2AuthenticationManagerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/oauth2/Oauth2AuthenticationManagerTest.java
@@ -1,23 +1,21 @@
 package org.opendevstack.provision.authentication.oauth2;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import com.atlassian.crowd.integration.springsecurity.user.CrowdUserDetails;
 import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.test.context.TestSecurityContextHolder;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
-@DirtiesContext
+@ExtendWith(SpringExtension.class)
 public class Oauth2AuthenticationManagerTest {
 
   @MockBean private DefaultOidcUser defaultOidcUser;

--- a/src/test/java/org/opendevstack/provision/authentication/oauth2/Oauth2LogoutHandlerLogoutFromIDMTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/oauth2/Oauth2LogoutHandlerLogoutFromIDMTest.java
@@ -6,19 +6,17 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.Authentication;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
-@DirtiesContext
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = Oauth2LogoutHandler.class)
 @TestPropertySource(
     properties = {

--- a/src/test/java/org/opendevstack/provision/authentication/oauth2/Oauth2LogoutHandlerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/oauth2/Oauth2LogoutHandlerTest.java
@@ -6,18 +6,16 @@ import static org.mockito.Mockito.verify;
 import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.Authentication;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
-@DirtiesContext
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = Oauth2LogoutHandler.class)
 @TestPropertySource(
     properties = {

--- a/src/test/java/org/opendevstack/provision/authentication/oauth2/ProvAppExpressionHandlerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/oauth2/ProvAppExpressionHandlerTest.java
@@ -13,42 +13,53 @@
  */
 package org.opendevstack.provision.authentication.oauth2;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.aopalliance.intercept.MethodInvocation;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.opendevstack.provision.authentication.authorization.ProvAppExpressionHandler;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @DirtiesContext
 public class ProvAppExpressionHandlerTest {
 
   @MockBean private Authentication authentication;
-
   @MockBean private MethodInvocation methodInvocation;
 
   private static final String USER_ROLE = "userRole";
-
   private static final String ADMIN_ROLE = "adminRole";
 
   private ProvAppExpressionHandler provAppExpressionHandler;
 
-  @Before
+  @BeforeEach
   public void setup() {
     provAppExpressionHandler = new ProvAppExpressionHandler(USER_ROLE, ADMIN_ROLE);
   }
 
   @Test
   public void createEvaluationContextInternal() {
+    MethodInvocation mi = mock(MethodInvocation.class);
+    try {
+      given(mi.getMethod()).willReturn(String.class.getMethod("toString"));
+    } catch (NoSuchMethodException e) {
+      e.printStackTrace();
+    }
+    given(mi.getThis()).willReturn(this);
+
+
+
     StandardEvaluationContext evaluationContextInternal =
-        provAppExpressionHandler.createEvaluationContextInternal(authentication, methodInvocation);
+        provAppExpressionHandler.createEvaluationContextInternal(authentication, mi);
     ProvAppExpressionHandler handler =
         (ProvAppExpressionHandler)
             evaluationContextInternal.lookupVariable(ProvAppExpressionHandler.PROV_APP);

--- a/src/test/java/org/opendevstack/provision/authentication/oauth2/ProvAppExpressionHandlerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/oauth2/ProvAppExpressionHandlerTest.java
@@ -14,7 +14,6 @@
 package org.opendevstack.provision.authentication.oauth2;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -34,7 +33,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 public class ProvAppExpressionHandlerTest {
 
   @MockBean private Authentication authentication;
-  @MockBean private MethodInvocation methodInvocation;
 
   private static final String USER_ROLE = "userRole";
   private static final String ADMIN_ROLE = "adminRole";
@@ -47,16 +45,10 @@ public class ProvAppExpressionHandlerTest {
   }
 
   @Test
-  public void createEvaluationContextInternal() {
+  public void createEvaluationContextInternal() throws NoSuchMethodException {
     MethodInvocation mi = mock(MethodInvocation.class);
-    try {
-      given(mi.getMethod()).willReturn(String.class.getMethod("toString"));
-    } catch (NoSuchMethodException e) {
-      e.printStackTrace();
-    }
-    given(mi.getThis()).willReturn(this);
-
-
+    when(mi.getMethod()).thenReturn(String.class.getMethod("toString"));
+    when(mi.getThis()).thenReturn(this);
 
     StandardEvaluationContext evaluationContextInternal =
         provAppExpressionHandler.createEvaluationContextInternal(authentication, mi);

--- a/src/test/java/org/opendevstack/provision/authentication/oauth2/RoleAwareOAuth2UserServiceTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/oauth2/RoleAwareOAuth2UserServiceTest.java
@@ -1,6 +1,6 @@
 package org.opendevstack.provision.authentication.oauth2;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -8,15 +8,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(SpringExtension.class)
 public class RoleAwareOAuth2UserServiceTest {
 
   @Mock private DefaultOidcUser oidcUser;
@@ -28,7 +27,7 @@ public class RoleAwareOAuth2UserServiceTest {
   private Token token;
   private JsonNode jwt;
 
-  @Before
+  @BeforeEach
   public void setup() {
 
     List<String> roles = new ArrayList();
@@ -46,14 +45,14 @@ public class RoleAwareOAuth2UserServiceTest {
     when(oidcUser.getEmail()).thenReturn(email);
     when(oidcUser.getName()).thenReturn(username);
 
-    Assert.assertEquals(email, RoleAwareOAuth2UserService.resolveUsername(oidcUser, true));
-    Assert.assertEquals(username, RoleAwareOAuth2UserService.resolveUsername(oidcUser, false));
+    assertEquals(email, RoleAwareOAuth2UserService.resolveUsername(oidcUser, true));
+    assertEquals(username, RoleAwareOAuth2UserService.resolveUsername(oidcUser, false));
 
     try {
       RoleAwareOAuth2UserService.resolveUsername(null, false);
       fail();
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("oidcUser"));
+      assertTrue(e.getMessage().contains("oidcUser"));
     }
   }
 
@@ -64,21 +63,21 @@ public class RoleAwareOAuth2UserServiceTest {
       RoleAwareOAuth2UserService.extractRoles(null, userRolesExpression, false);
       fail();
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("token"));
+      assertTrue(e.getMessage().contains("token"));
     }
 
     try {
       RoleAwareOAuth2UserService.extractRoles(jwt, null, false);
       fail();
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("userRolesExpression"));
+      assertTrue(e.getMessage().contains("userRolesExpression"));
     }
 
     try {
       RoleAwareOAuth2UserService.extractRoles(jwt, "does-not-start-with-slash", false);
       fail();
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("must start with '/'"));
+      assertTrue(e.getMessage().contains("must start with '/'"));
     }
   }
 
@@ -89,22 +88,22 @@ public class RoleAwareOAuth2UserServiceTest {
     List<String> mappedRoles =
         RoleAwareOAuth2UserService.extractRoles(jwt, userRolesExpression, convertToLowerCase);
 
-    Assert.assertEquals(convertToLowerCase, mappedRoles.contains(ROLE_1.toLowerCase()));
-    Assert.assertEquals(!convertToLowerCase, mappedRoles.contains(ROLE_1));
+    assertEquals(convertToLowerCase, mappedRoles.contains(ROLE_1.toLowerCase()));
+    assertEquals(!convertToLowerCase, mappedRoles.contains(ROLE_1));
 
     convertToLowerCase = false;
     mappedRoles =
         RoleAwareOAuth2UserService.extractRoles(jwt, userRolesExpression, convertToLowerCase);
 
-    Assert.assertEquals(convertToLowerCase, mappedRoles.contains(ROLE_1.toLowerCase()));
-    Assert.assertEquals(!convertToLowerCase, mappedRoles.contains(ROLE_1));
+    assertEquals(convertToLowerCase, mappedRoles.contains(ROLE_1.toLowerCase()));
+    assertEquals(!convertToLowerCase, mappedRoles.contains(ROLE_1));
   }
 
   @Test
   public void whenNotValidUserRolesExpressionThenMappedRolesEmpty() {
 
     List<String> roles = RoleAwareOAuth2UserService.extractRoles(jwt, "/doesnotexists", false);
-    Assert.assertNotNull(roles);
+    assertNotNull(roles);
   }
 
   @Test

--- a/src/test/java/org/opendevstack/provision/config/JiraProjectTemplatePropertiesTest.java
+++ b/src/test/java/org/opendevstack/provision/config/JiraProjectTemplatePropertiesTest.java
@@ -13,19 +13,15 @@
  */
 package org.opendevstack.provision.config;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opendevstack.provision.SpringBoot;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @DirtiesContext
 @ActiveProfiles("utest")
 public class JiraProjectTemplatePropertiesTest {

--- a/src/test/java/org/opendevstack/provision/config/OpenshiftServiceConfigTest.java
+++ b/src/test/java/org/opendevstack/provision/config/OpenshiftServiceConfigTest.java
@@ -13,21 +13,17 @@
  */
 package org.opendevstack.provision.config;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opendevstack.provision.SpringBoot;
+import org.junit.jupiter.api.Test;
 import org.opendevstack.provision.services.openshift.OpenshiftClient;
 import org.opendevstack.provision.services.openshift.OpenshiftService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @DirtiesContext
 @ActiveProfiles("utest")
 public class OpenshiftServiceConfigTest {

--- a/src/test/java/org/opendevstack/provision/controller/ApplicationInfoAPIControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/ApplicationInfoAPIControllerTest.java
@@ -21,10 +21,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import org.hamcrest.CoreMatchers;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opendevstack.provision.SpringBoot;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.opendevstack.provision.adapter.IBugtrackerAdapter;
 import org.opendevstack.provision.adapter.ICollaborationAdapter;
 import org.opendevstack.provision.adapter.IODSAuthnzAdapter;
@@ -41,7 +39,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -50,10 +47,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    classes = SpringBoot.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("utest")
 @DirtiesContext
 public class ApplicationInfoAPIControllerTest {
@@ -84,7 +78,7 @@ public class ApplicationInfoAPIControllerTest {
   @Value("${idmanager.group.opendevstack-administrators}")
   private String idmanagerAdminGroup;
 
-  @Before
+  @BeforeEach
   public void setup() {
 
     mockMvc =

--- a/src/test/java/org/opendevstack/provision/controller/CheckPreconditionsResponseTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/CheckPreconditionsResponseTest.java
@@ -14,11 +14,12 @@
 
 package org.opendevstack.provision.controller;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
@@ -33,7 +34,7 @@ public class CheckPreconditionsResponseTest {
     String expectedJson =
         "{\"endpoint\":\"ADD_PROJECT\",\"stage\":\"CREATE_PROJECT\",\"status\":\"FAILED\",\"errors\":[{\"error-code\":\"EXCEPTION\",\"error-message\":\"error1\"}]}";
 
-    Assert.assertEquals(
+    assertEquals(
         expectedJson,
         CheckPreconditionsResponse.failedAsJson(
             CheckPreconditionsResponse.JobStage.CREATE_PROJECT, "error1"));
@@ -46,7 +47,7 @@ public class CheckPreconditionsResponseTest {
     errors.add(CheckPreconditionFailure.getUnexistantGroupInstance("failure1"));
     errors.add(CheckPreconditionFailure.getUnexistantUserInstance("failure2"));
 
-    Assert.assertEquals(
+    assertEquals(
         "CHECK_PRECONDITIONS=FAILED"
             + System.lineSeparator()
             + "ERRORS=[CheckPreconditionFailure{error-code='UNEXISTANT_GROUP', detail='failure1'}, CheckPreconditionFailure{error-code='UNEXISTANT_USER', detail='failure2'}]"
@@ -57,7 +58,7 @@ public class CheckPreconditionsResponseTest {
     String expectedJson =
         "{\"endpoint\":\"ADD_PROJECT\",\"stage\":\"CHECK_PRECONDITIONS\",\"status\":\"FAILED\",\"errors\":[{\"error-code\":\"UNEXISTANT_GROUP\",\"error-message\":\"failure1\"},{\"error-code\":\"UNEXISTANT_USER\",\"error-message\":\"failure2\"}]}";
 
-    Assert.assertEquals(
+    assertEquals(
         expectedJson,
         CheckPreconditionsResponse.checkPreconditionFailed(
             MediaType.APPLICATION_JSON_VALUE,
@@ -68,14 +69,13 @@ public class CheckPreconditionsResponseTest {
   @Test
   public void isJsonContentType() {
 
-    Assert.assertFalse(CheckPreconditionsResponse.isJsonContentType(null));
+    assertFalse(CheckPreconditionsResponse.isJsonContentType(null));
 
-    Assert.assertFalse(CheckPreconditionsResponse.isJsonContentType("something"));
+    assertFalse(CheckPreconditionsResponse.isJsonContentType("something"));
 
-    Assert.assertTrue(
-        CheckPreconditionsResponse.isJsonContentType(MediaType.APPLICATION_JSON_VALUE));
+    assertTrue(CheckPreconditionsResponse.isJsonContentType(MediaType.APPLICATION_JSON_VALUE));
 
-    Assert.assertTrue(
+    assertTrue(
         CheckPreconditionsResponse.isJsonContentType(
             MediaType.APPLICATION_JSON_VALUE + "; " + " more text"));
   }
@@ -83,14 +83,14 @@ public class CheckPreconditionsResponseTest {
   @Test
   public void successfulResponse() throws JsonProcessingException {
 
-    Assert.assertEquals(
+    assertEquals(
         "CHECK_PRECONDITIONS=COMPLETED_SUCCESSFULLY",
         CheckPreconditionsResponse.successful(
             null, CheckPreconditionsResponse.JobStage.CHECK_PRECONDITIONS));
 
     String expectedJson =
         "{\"endpoint\":\"ADD_PROJECT\",\"stage\":\"CHECK_PRECONDITIONS\",\"status\":\"COMPLETED_SUCCESSFULLY\"}";
-    Assert.assertEquals(
+    assertEquals(
         expectedJson,
         CheckPreconditionsResponse.successful(
             MediaType.APPLICATION_JSON_VALUE,

--- a/src/test/java/org/opendevstack/provision/controller/DefaultControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/DefaultControllerTest.java
@@ -20,11 +20,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import org.hamcrest.CoreMatchers;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.opendevstack.provision.SpringBoot;
 import org.opendevstack.provision.adapter.IBugtrackerAdapter;
 import org.opendevstack.provision.adapter.ICollaborationAdapter;
 import org.opendevstack.provision.adapter.IJobExecutionAdapter;
@@ -35,23 +33,18 @@ import org.opendevstack.provision.model.AboutChangesData;
 import org.opendevstack.provision.services.StorageAdapter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.MOCK, classes = SpringBoot.class)
-@DirtiesContext
-@ActiveProfiles("crowd,utestcrowd,quickstarters")
+@SpringBootTest
+@ActiveProfiles({"crowd", "utestcrowd", "quickstarters"})
 public class DefaultControllerTest {
 
   @MockBean private IJobExecutionAdapter jobExecutionAdapter;
@@ -72,7 +65,7 @@ public class DefaultControllerTest {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void setUp() {
 
     mockMvc =

--- a/src/test/java/org/opendevstack/provision/controller/E2EProjectAPIControllerSecurityTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/E2EProjectAPIControllerSecurityTest.java
@@ -13,7 +13,7 @@
  */
 package org.opendevstack.provision.controller;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
@@ -21,10 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opendevstack.provision.SpringBoot;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.opendevstack.provision.authentication.basic.BasicAuthSecurityTestConfig;
 import org.opendevstack.provision.model.OpenProjectData;
 import org.opendevstack.provision.services.StorageAdapter;
@@ -35,7 +33,6 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.*;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * This E2E test focus in testing 2 things: - basic auth authentication - authorization negative
@@ -44,21 +41,13 @@ import org.springframework.test.context.junit4.SpringRunner;
  * <p>NOTES: - positive cases are tested in E2EProjectAPIControllerTest - see
  * BasicAuthSecurityConfig.class, it configures a TestingAuthenticationProvider with test users
  */
-@RunWith(SpringRunner.class)
-@SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    classes = SpringBoot.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext
 @ActiveProfiles("utest")
 public class E2EProjectAPIControllerSecurityTest {
 
   public static final String TEST_VALID_CREDENTIAL =
       BasicAuthSecurityTestConfig.TEST_VALID_CREDENTIAL;
-
-  @MockBean private StorageAdapter storageAdapter;
-
-  @Autowired private TestRestTemplate template;
-
   private final String admin = BasicAuthSecurityTestConfig.TEST_ADMIN_USERNAME;
   private final String user = BasicAuthSecurityTestConfig.TEST_USER_USERNAME;
   private final String unknownUser =
@@ -67,7 +56,6 @@ public class E2EProjectAPIControllerSecurityTest {
   private final String validCredential = BasicAuthSecurityTestConfig.TEST_VALID_CREDENTIAL;
   private final String invalidCredential = "invalidSecret";
   private final String projectAPI = "/" + ProjectAPI.API_V2_PROJECT;
-
   private final List<String> allGetAPIs =
       List.of(
           projectAPI, // get all projects API
@@ -77,12 +65,13 @@ public class E2EProjectAPIControllerSecurityTest {
           projectAPI + "/template/KEY",
           projectAPI + "/key/validate?projectKey=KEY",
           projectAPI + "/key/generate?name=NAME");
-
+  @MockBean private StorageAdapter storageAdapter;
+  @Autowired private TestRestTemplate template;
   private HttpHeaders headers = new HttpHeaders();
 
   private OpenProjectData projectData;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     headers.setContentType(MediaType.APPLICATION_JSON);
     headers.setAccept(List.of(MediaType.APPLICATION_JSON));
@@ -234,11 +223,11 @@ public class E2EProjectAPIControllerSecurityTest {
 
     HttpStatus responseStatus = request.apply(username, credential);
     assertEquals(
+        expected,
+        responseStatus,
         String.format(
             "Authentication failed with unexpected return code for user '%s:%s' ",
-            username, credential),
-        expected,
-        responseStatus);
+            username, credential));
   }
 
   public void assertRequests(

--- a/src/test/java/org/opendevstack/provision/controller/E2EProjectAPIControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/E2EProjectAPIControllerTest.java
@@ -16,7 +16,7 @@ package org.opendevstack.provision.controller;
 
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.opendevstack.provision.authentication.basic.BasicAuthSecurityTestConfig.*;
 import static org.opendevstack.provision.util.RestClientCallArgumentMatcher.matchesClientCall;
@@ -36,15 +36,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.verification.VerificationMode;
-import org.opendevstack.provision.SpringBoot;
 import org.opendevstack.provision.adapter.IODSAuthnzAdapter;
 import org.opendevstack.provision.authentication.basic.BasicAuthSecurityTestConfig;
 import org.opendevstack.provision.model.ExecutionJob;
@@ -85,7 +82,6 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
@@ -94,11 +90,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 /** End to end testcase with real result data - only mock is the RestClient - to feed the json */
-@RunWith(SpringRunner.class)
-@SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    classes = SpringBoot.class)
-@ActiveProfiles("utest,quickstarters")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"utest", "quickstarters"})
 @DirtiesContext
 public class E2EProjectAPIControllerTest {
 
@@ -158,7 +151,7 @@ public class E2EProjectAPIControllerTest {
 
   private String VALID_CREDENTIAL = BasicAuthSecurityTestConfig.TEST_VALID_CREDENTIAL;
 
-  @Before
+  @BeforeEach
   public void setUp() {
 
     E2EProjectAPIControllerTest.initLocalStorage(
@@ -187,16 +180,16 @@ public class E2EProjectAPIControllerTest {
   }
 
   public static void initLocalStorage(LocalStorage realStorageAdapter, File resultsDir) {
-    Assert.assertNotNull(realStorageAdapter.getLocalStoragePath());
-    Assert.assertTrue(resultsDir.exists());
-    Assert.assertTrue(resultsDir.isDirectory());
+    assertNotNull(realStorageAdapter.getLocalStoragePath());
+    assertTrue(resultsDir.exists());
+    assertTrue(resultsDir.isDirectory());
     realStorageAdapter.setLocalStoragePath(resultsDir.getPath());
-    Assert.assertNotNull(realStorageAdapter.getLocalStoragePath());
+    assertNotNull(realStorageAdapter.getLocalStoragePath());
     e2eLogger.info(
         "Local storage initialized. LocalStoragePath={}", realStorageAdapter.getStoragePath());
   }
 
-  @After
+  @AfterEach
   public void cleanUpTempDir() {
     new File(realLocalStorageAdapter.getLocalStoragePath()).deleteOnExit();
   }
@@ -665,29 +658,31 @@ public class E2EProjectAPIControllerTest {
     assertActualJobMatchesInputParams(actualJob, configuredResponse);
 
     // verify 2 repos are created
-    assertEquals("Repository created", 2, resultProject.repositories.size());
+    assertEquals(2, resultProject.repositories.size(), "Repository created");
   }
 
   private void assertActualJobMatchesInputParams(
       ExecutionJob actualJob, CreateProjectResponse configuredResponse) {
     String namespace = configuredResponse.extractNamespace();
-    Assertions.assertThat(actualJob.getName())
-        .isEqualTo(namespace + "-" + configuredResponse.extractBuildConfigName());
+    Assertions.assertEquals(
+        actualJob.getName(), namespace + "-" + configuredResponse.extractBuildConfigName());
 
-    Assertions.assertThat(actualJob.getUrl())
-        .contains(
-            format(
-                "https://jenkins-%s%s/job/%s/job/%s-%s/%s",
-                namespace,
-                projectOpenshiftBaseDomain,
-                namespace,
-                namespace,
-                configuredResponse.extractBuildConfigName(),
-                configuredResponse.extractBuildNumber()));
+    Assertions.assertTrue(
+        actualJob
+            .getUrl()
+            .contains(
+                format(
+                    "https://jenkins-%s%s/job/%s/job/%s-%s/%s",
+                    namespace,
+                    projectOpenshiftBaseDomain,
+                    namespace,
+                    namespace,
+                    configuredResponse.extractBuildConfigName(),
+                    configuredResponse.extractBuildNumber())));
 
     String expectedUrlSuffix =
         configuredResponse.extractBuildConfigName() + "/" + configuredResponse.extractBuildNumber();
-    Assertions.assertThat(actualJob.getUrl()).endsWith(expectedUrlSuffix);
+    assertTrue(actualJob.getUrl().endsWith(expectedUrlSuffix));
   }
 
   /** Test positive new quickstarter */
@@ -876,7 +871,7 @@ public class E2EProjectAPIControllerTest {
     OpenProjectData currentlyStoredProject =
         realLocalStorageAdapter.getProject(dataUpdate.projectKey);
 
-    Assertions.assertThat(currentlyStoredProject.getQuickstarters()).isEmpty();
+    assertTrue(currentlyStoredProject.getQuickstarters().isEmpty());
 
     // bitbucket repo creation for new quickstarter
     RepositoryData bitbucketRepositoryDataQSRepo =

--- a/src/test/java/org/opendevstack/provision/controller/ProjectApiControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/ProjectApiControllerTest.java
@@ -14,7 +14,7 @@
 
 package org.opendevstack.provision.controller;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.Mockito.*;
@@ -28,13 +28,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.verification.VerificationMode;
-import org.opendevstack.provision.SpringBoot;
 import org.opendevstack.provision.adapter.*;
 import org.opendevstack.provision.adapter.ISCMAdapter.URL_TYPE;
 import org.opendevstack.provision.adapter.exception.AdapterException;
@@ -61,7 +58,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
@@ -69,11 +65,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    classes = SpringBoot.class)
-@ActiveProfiles("crowd,utestcrowd,quickstarters")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"crowd", "utestcrowd", "quickstarters"})
 @DirtiesContext
 public class ProjectApiControllerTest {
 
@@ -112,7 +105,7 @@ public class ProjectApiControllerTest {
 
   private OpenProjectData data;
 
-  @Before
+  @BeforeEach
   public void setUp() {
 
     mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
@@ -1076,7 +1069,7 @@ public class ProjectApiControllerTest {
           null, new ArrayList<Consumer<Map<String, String>>>());
     } catch (IllegalArgumentException e) {
       // expected!
-      Assert.assertTrue(e.getMessage().contains("null"));
+      assertTrue(e.getMessage().contains("null"));
     }
 
     // case validators list is empty
@@ -1085,7 +1078,7 @@ public class ProjectApiControllerTest {
           data, new ArrayList<Consumer<Map<String, String>>>());
     } catch (IllegalArgumentException e) {
       // expected!
-      Assert.assertTrue(e.getMessage().contains("validators"));
+      assertTrue(e.getMessage().contains("validators"));
     }
 
     // case data is not null and validators is not empty

--- a/src/test/java/org/opendevstack/provision/controller/QuickstarterApiControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/QuickstarterApiControllerTest.java
@@ -25,11 +25,9 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.opendevstack.provision.SpringBoot;
 import org.opendevstack.provision.adapter.IODSAuthnzAdapter;
 import org.opendevstack.provision.model.ExecutionsData;
 import org.opendevstack.provision.model.OpenProjectData;
@@ -38,20 +36,17 @@ import org.opendevstack.provision.services.JenkinsPipelineAdapter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @DirtiesContext
 @ActiveProfiles("utest")
 public class QuickstarterApiControllerTest {
@@ -73,7 +68,7 @@ public class QuickstarterApiControllerTest {
 
   private static final String TEST_ADMIN_EMAIL = "testUserName@example.com";
 
-  @Before
+  @BeforeEach
   public void init() {
     mockMvc =
         MockMvcBuilders.webAppContextSetup(context)

--- a/src/test/java/org/opendevstack/provision/model/OpenProjectDataValidatorTest.java
+++ b/src/test/java/org/opendevstack/provision/model/OpenProjectDataValidatorTest.java
@@ -14,6 +14,8 @@
 
 package org.opendevstack.provision.model;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.opendevstack.provision.model.OpenProjectData.COMPONENT_ID_KEY;
 import static org.opendevstack.provision.model.OpenProjectData.COMPONENT_TYPE_KEY;
 
@@ -23,15 +25,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class OpenProjectDataValidatorTest {
 
   private OpenProjectData data;
 
-  @Before
+  @BeforeEach
   public void setup() {
     data = new OpenProjectData();
     data.projectKey = "KEY";
@@ -62,7 +63,7 @@ public class OpenProjectDataValidatorTest {
       data.getQuickstarters().stream().findFirst().get().put(COMPONENT_ID_KEY, null);
       data.quickstarters.forEach(validator);
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("null"));
+      assertTrue(e.getMessage().contains("null"));
     }
 
     // case component id is empty
@@ -71,7 +72,7 @@ public class OpenProjectDataValidatorTest {
       data.getQuickstarters().stream().findFirst().get().put(COMPONENT_ID_KEY, empty);
       data.quickstarters.forEach(validator);
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("empty"));
+      assertTrue(e.getMessage().contains("empty"));
     }
 
     // case component id longer than max length
@@ -82,10 +83,10 @@ public class OpenProjectDataValidatorTest {
       data.quickstarters.forEach(validator);
     } catch (IllegalArgumentException e) {
       String errorMessage = e.getMessage();
-      Assert.assertTrue(errorMessage.contains(tooLong));
+      assertTrue(errorMessage.contains(tooLong));
       // special assert that verifies 2 errors: too long and not valid chars
-      Assert.assertTrue(errorMessage.contains("not valid name"));
-      //            Assert.assertEquals(2,
+      assertTrue(errorMessage.contains("not valid name"));
+      //            assertEquals(2,
       // errorMessage.split(OpenProjectDataValidator.VALIDATION_ERROR_MESSAGE_SEPARATOR).length);
     }
 
@@ -96,7 +97,7 @@ public class OpenProjectDataValidatorTest {
       data.getQuickstarters().stream().findFirst().get().put(COMPONENT_ID_KEY, tooShort);
       data.quickstarters.forEach(validator);
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(tooShort));
+      assertTrue(e.getMessage().contains(tooShort));
     }
 
     // case component id is longer or equal than max length
@@ -117,8 +118,8 @@ public class OpenProjectDataValidatorTest {
       data.getQuickstarters().stream().findFirst().get().put(COMPONENT_TYPE_KEY, null);
       data.quickstarters.forEach(validator);
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("null"));
-      Assert.assertTrue(e.getMessage().contains(COMPONENT_TYPE_KEY));
+      assertTrue(e.getMessage().contains("null"));
+      assertTrue(e.getMessage().contains(COMPONENT_TYPE_KEY));
     }
 
     // case component id is null
@@ -127,8 +128,8 @@ public class OpenProjectDataValidatorTest {
       data.getQuickstarters().stream().findFirst().get().put(COMPONENT_ID_KEY, null);
       data.quickstarters.forEach(validator);
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("null"));
-      Assert.assertTrue(e.getMessage().contains(COMPONENT_ID_KEY));
+      assertTrue(e.getMessage().contains("null"));
+      assertTrue(e.getMessage().contains(COMPONENT_ID_KEY));
     }
 
     // case component type equals component id
@@ -138,7 +139,7 @@ public class OpenProjectDataValidatorTest {
       data.getQuickstarters().stream().findFirst().get().put(COMPONENT_TYPE_KEY, same);
       data.quickstarters.forEach(validator);
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("is equal"));
+      assertTrue(e.getMessage().contains("is equal"));
     }
 
     // case component type not equals component id
@@ -180,9 +181,9 @@ public class OpenProjectDataValidatorTest {
           try {
             data.getQuickstarters().stream().findFirst().get().put(COMPONENT_ID_KEY, notValid);
             data.quickstarters.forEach(validator);
-            Assert.fail(notValid + " is a not valid component id!");
+            fail(notValid + " is a not valid component id!");
           } catch (IllegalArgumentException e) {
-            Assert.assertTrue(e.getMessage().contains("not valid name"));
+            assertTrue(e.getMessage().contains("not valid name"));
           }
         });
 
@@ -193,9 +194,9 @@ public class OpenProjectDataValidatorTest {
               try {
                 data.getQuickstarters().stream().findFirst().get().put(COMPONENT_ID_KEY, notValid);
                 data.quickstarters.forEach(validator);
-                Assert.fail(notValid + " is a not valid component id!");
+                fail(notValid + " is a not valid component id!");
               } catch (IllegalArgumentException e) {
-                Assert.assertTrue(e.getMessage().contains("not valid name"));
+                assertTrue(e.getMessage().contains("not valid name"));
               }
             });
 

--- a/src/test/java/org/opendevstack/provision/model/ProjectDataTest.java
+++ b/src/test/java/org/opendevstack/provision/model/ProjectDataTest.java
@@ -14,11 +14,11 @@
 
 package org.opendevstack.provision.model;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Test Project data equals / hashcode */
 public class ProjectDataTest {

--- a/src/test/java/org/opendevstack/provision/model/jenkins/JobTest.java
+++ b/src/test/java/org/opendevstack/provision/model/jenkins/JobTest.java
@@ -1,9 +1,10 @@
 package org.opendevstack.provision.model.jenkins;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JobTest {
 
@@ -12,11 +13,11 @@ public class JobTest {
   @Test
   public void createJobOnlyWithNameAndRepo() {
     Job job = new Job("jobName", "gitRepoName.git", Optional.empty(), Optional.empty(), odsGitRef);
-    assertThat(job.getName()).isEqualTo("jobName");
-    assertThat(job.isEnabled()).isTrue();
-    assertThat(job.getBranch()).isEqualTo(odsGitRef);
-    assertThat(job.getGitRepoName()).isEqualTo("gitRepoName");
-    assertThat(job.getJenkinsfilePath()).isEqualTo("jobName/Jenkinsfile");
+    assertEquals("jobName", job.getName());
+    assertTrue(job.isEnabled());
+    assertEquals(odsGitRef, job.getBranch());
+    assertEquals("gitRepoName", job.getGitRepoName());
+    assertEquals("jobName/Jenkinsfile", job.getJenkinsfilePath());
   }
 
   @Test
@@ -24,11 +25,11 @@ public class JobTest {
     Job job =
         new Job(
             "jobName", "gitRepoName.git", Optional.of("customBranch"), Optional.empty(), odsGitRef);
-    assertThat(job.getName()).isEqualTo("jobName");
-    assertThat(job.isEnabled()).isTrue();
-    assertThat(job.getBranch()).isEqualTo("customBranch");
-    assertThat(job.getGitRepoName()).isEqualTo("gitRepoName");
-    assertThat(job.getJenkinsfilePath()).isEqualTo("jobName/Jenkinsfile");
+    assertEquals("jobName", job.getName());
+    assertTrue(job.isEnabled());
+    assertEquals("customBranch", job.getBranch());
+    assertEquals("gitRepoName", job.getGitRepoName());
+    assertEquals("jobName/Jenkinsfile", job.getJenkinsfilePath());
   }
 
   @Test
@@ -40,10 +41,10 @@ public class JobTest {
             Optional.empty(),
             Optional.of("a/custom/path/Jenkinsfile"),
             odsGitRef);
-    assertThat(job.getName()).isEqualTo("jobName");
-    assertThat(job.isEnabled()).isTrue();
-    assertThat(job.getBranch()).isEqualTo(odsGitRef);
-    assertThat(job.getGitRepoName()).isEqualTo("gitRepoName");
-    assertThat(job.getJenkinsfilePath()).isEqualTo("a/custom/path/Jenkinsfile");
+    assertEquals("jobName", job.getName());
+    assertTrue(job.isEnabled());
+    assertEquals(odsGitRef, job.getBranch());
+    assertEquals("gitRepoName", job.getGitRepoName());
+    assertEquals("a/custom/path/Jenkinsfile", job.getJenkinsfilePath());
   }
 }

--- a/src/test/java/org/opendevstack/provision/model/webhookproxy/CreateProjectResponseTest.java
+++ b/src/test/java/org/opendevstack/provision/model/webhookproxy/CreateProjectResponseTest.java
@@ -1,12 +1,12 @@
 package org.opendevstack.provision.model.webhookproxy;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
@@ -25,33 +25,31 @@ public class CreateProjectResponseTest {
     String jsonFile = "sample-create-project-response.json";
     CreateProjectResponse actual = readTestData(jsonFile, CreateProjectResponse.class);
 
-    assertThat(actual.getKind()).isEqualTo("Build");
-    assertThat(actual.getApiVersion()).isEqualTo("build.openshift.io/v1");
+    assertEquals("Build", actual.getKind());
+    assertEquals("build.openshift.io/v1", actual.getApiVersion());
     Metadata metadata = actual.getMetadata();
-    assertThat(metadata.getName()).isEqualTo("ods-corejob-create-projects-tst04-production-1");
-    assertThat(metadata.getNamespace()).isEqualTo("prov-cd");
-    assertThat(metadata.getResourceVersion()).isEqualTo("913911");
-    assertThat(metadata.getSelfLink())
-        .isEqualTo(
-            "/apis/build.openshift.io/v1/namespaces/prov-cd/buildconfigs/ods-corejob-create-projects-tst04-production-1/instantiate");
-    assertThat(metadata.getUid()).isEqualTo("b0cb02d7-11a9-11ea-9997-08002750261b");
+    assertEquals("ods-corejob-create-projects-tst04-production-1", metadata.getName());
+    assertEquals("prov-cd", metadata.getNamespace());
+    assertEquals("913911", metadata.getResourceVersion());
+    assertEquals(
+        "/apis/build.openshift.io/v1/namespaces/prov-cd/buildconfigs/ods-corejob-create-projects-tst04-production-1/instantiate",
+        metadata.getSelfLink());
+    assertEquals("b0cb02d7-11a9-11ea-9997-08002750261b", metadata.getUid());
 
     Annotations annotations = metadata.getAnnotations();
-    assertThat(annotations.getBuildConfigName())
-        .isEqualTo("ods-corejob-create-projects-tst04-production");
-    assertThat(annotations.getBuildNumber()).isEqualTo("1");
+    assertEquals("ods-corejob-create-projects-tst04-production", annotations.getBuildConfigName());
+    assertEquals("1", annotations.getBuildNumber());
 
     Labels labels = metadata.getLabels();
-    assertThat(labels.getBuildconfig()).isEqualTo("ods-corejob-create-projects-tst04-production");
-    assertThat(labels.getBuildConfigName())
-        .isEqualTo("ods-corejob-create-projects-tst04-production");
+    assertEquals("ods-corejob-create-projects-tst04-production", labels.getBuildconfig());
+    assertEquals("ods-corejob-create-projects-tst04-production", labels.getBuildConfigName());
 
     Status status = actual.getStatus();
-    assertThat(status.getPhase()).isEqualTo("New");
+    assertEquals("New", status.getPhase());
     Config config = status.getConfig();
-    assertThat(config.getKind()).isEqualTo("BuildConfig");
-    assertThat(config.getName()).isEqualTo("ods-corejob-create-projects-tst04-production");
-    assertThat(config.getNamespace()).isEqualTo("prov-cd");
+    assertEquals("BuildConfig", config.getKind());
+    assertEquals("ods-corejob-create-projects-tst04-production", config.getName());
+    assertEquals("prov-cd", config.getNamespace());
   }
 
   private <T> T readTestData(String name, Class<T> returnType) throws Exception {

--- a/src/test/java/org/opendevstack/provision/services/AbstractBaseServiceAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/AbstractBaseServiceAdapterTest.java
@@ -1,7 +1,7 @@
 package org.opendevstack.provision.services;
 
 import java.io.IOException;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.verification.VerificationMode;
@@ -20,7 +20,7 @@ public abstract class AbstractBaseServiceAdapterTest {
 
   private RestClientMockHelper mockHelper;
 
-  @Before
+  @BeforeEach
   public void beforeTest() {
     MockitoAnnotations.initMocks(this);
     mockHelper = new RestClientMockHelper(restClient);

--- a/src/test/java/org/opendevstack/provision/services/BitbucketAdapterMT.java
+++ b/src/test/java/org/opendevstack/provision/services/BitbucketAdapterMT.java
@@ -1,9 +1,7 @@
 package org.opendevstack.provision.services;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opendevstack.provision.SpringBoot;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.opendevstack.provision.adapter.IServiceAdapter.LIFECYCLE_STAGE;
 import org.opendevstack.provision.model.OpenProjectData;
 import org.opendevstack.provision.storage.LocalStorage;
@@ -11,12 +9,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = SpringBoot.class)
-@ActiveProfiles("oauth2,oauth2private")
-@Ignore("Only exists for manual execution")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"oauth2", "oauth2private"})
+@Disabled("Only exists for manual execution")
 public class BitbucketAdapterMT {
 
   @Autowired private BitbucketAdapter bitbucketAdapter;

--- a/src/test/java/org/opendevstack/provision/services/BitbucketAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/BitbucketAdapterTest.java
@@ -14,7 +14,7 @@
 
 package org.opendevstack.provision.services;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -31,14 +31,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.opendevstack.provision.SpringBoot;
 import org.opendevstack.provision.adapter.IODSAuthnzAdapter;
 import org.opendevstack.provision.adapter.ISCMAdapter.URL_TYPE;
 import org.opendevstack.provision.adapter.exception.AdapterException;
@@ -54,7 +51,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.core.Authentication;
@@ -62,12 +58,10 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @DirtiesContext
-@ActiveProfiles("utest,quickstarters")
+@ActiveProfiles({"utest", "quickstarters"})
 public class BitbucketAdapterTest extends AbstractBaseServiceAdapterTest {
 
   @Value("${openshift.jenkins.project.webhookproxy.events}")
@@ -89,7 +83,7 @@ public class BitbucketAdapterTest extends AbstractBaseServiceAdapterTest {
   private static TestDataFileReader fileReader =
       new TestDataFileReader(TestDataFileReader.TEST_DATA_FILE_DIR);
 
-  @Before
+  @BeforeEach
   public void initTests() {
     when(authnzAdapter.getUserName()).thenReturn(TEST_USER_NAME);
     when(authnzAdapter.getUserPassword()).thenReturn(TEST_USER_PASSWORD);
@@ -606,8 +600,8 @@ public class BitbucketAdapterTest extends AbstractBaseServiceAdapterTest {
       fail();
 
     } catch (CreateProjectPreconditionException e) {
-      Assert.assertTrue(e.getMessage().contains("Unexpected error"));
-      Assert.assertTrue(e.getMessage().contains(project.projectKey));
+      assertTrue(e.getMessage().contains("Unexpected error"));
+      assertTrue(e.getMessage().contains(project.projectKey));
     }
   }
 }

--- a/src/test/java/org/opendevstack/provision/services/CleanupAtlassianProjectsMT.java
+++ b/src/test/java/org/opendevstack/provision/services/CleanupAtlassianProjectsMT.java
@@ -1,6 +1,6 @@
 package org.opendevstack.provision.services;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -8,11 +8,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opendevstack.provision.SpringBoot;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.opendevstack.provision.util.CredentialsInfo;
 import org.opendevstack.provision.util.rest.RestClient;
 import org.opendevstack.provision.util.rest.RestClientCall;
@@ -24,12 +22,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = SpringBoot.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("testods")
-@Ignore("Only exists for manual execution")
+@Disabled("Only exists for manual execution")
 public class CleanupAtlassianProjectsMT {
 
   private static final Logger LOG = LoggerFactory.getLogger(CleanupAtlassianProjectsMT.class);
@@ -53,7 +49,7 @@ public class CleanupAtlassianProjectsMT {
   @Value("${confluence.uri}")
   private String confluenceUrl;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     jiraCredentials = buildCredentials("jira");
     confluenceCredentials = buildCredentials("confluence");

--- a/src/test/java/org/opendevstack/provision/services/ConfluenceAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/ConfluenceAdapterTest.java
@@ -14,11 +14,9 @@
 
 package org.opendevstack.provision.services;
 
-import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasToString;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
@@ -30,13 +28,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mockito;
-import org.opendevstack.provision.SpringBoot;
 import org.opendevstack.provision.adapter.IODSAuthnzAdapter;
 import org.opendevstack.provision.adapter.IServiceAdapter;
 import org.opendevstack.provision.adapter.exception.AdapterException;
@@ -53,16 +48,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.http.HttpMethod;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @ActiveProfiles("utest")
 @DirtiesContext
 public class ConfluenceAdapterTest extends AbstractBaseServiceAdapterTest {
@@ -86,7 +78,7 @@ public class ConfluenceAdapterTest extends AbstractBaseServiceAdapterTest {
 
   @Autowired ConfigurableEnvironment environment;
 
-  @Before
+  @BeforeEach
   public void initTests() {
     when(authnzAdapter.getUserName()).thenReturn(TEST_USER_NAME);
     when(authnzAdapter.getUserPassword()).thenReturn(TEST_USER_PASSWORD);
@@ -240,9 +232,9 @@ public class ConfluenceAdapterTest extends AbstractBaseServiceAdapterTest {
       fail();
 
     } catch (CreateProjectPreconditionException e) {
-      Assert.assertTrue(e.getCause().getCause().getMessage().contains(ioException.getMessage()));
-      Assert.assertTrue(e.getMessage().contains(ConfluenceAdapter.ADAPTER_NAME));
-      Assert.assertTrue(e.getMessage().contains(project.projectKey));
+      assertTrue(e.getCause().getCause().getMessage().contains(ioException.getMessage()));
+      assertTrue(e.getMessage().contains(ConfluenceAdapter.ADAPTER_NAME));
+      assertTrue(e.getMessage().contains(project.projectKey));
     }
 
     NullPointerException npe = new NullPointerException("npe throw in unit test");
@@ -253,8 +245,8 @@ public class ConfluenceAdapterTest extends AbstractBaseServiceAdapterTest {
       fail();
 
     } catch (CreateProjectPreconditionException e) {
-      Assert.assertTrue(e.getMessage().contains("Unexpected error"));
-      Assert.assertTrue(e.getMessage().contains(project.projectKey));
+      assertTrue(e.getMessage().contains("Unexpected error"));
+      assertTrue(e.getMessage().contains(project.projectKey));
     }
   }
 
@@ -277,7 +269,7 @@ public class ConfluenceAdapterTest extends AbstractBaseServiceAdapterTest {
       checkProjectKeyExists.apply(new ArrayList<>());
       fail();
     } catch (Exception e) {
-      Assert.assertTrue(IllegalArgumentException.class.isInstance(e));
+      assertTrue(IllegalArgumentException.class.isInstance(e));
     }
 
     // Case IOException throw from rest client!
@@ -287,7 +279,7 @@ public class ConfluenceAdapterTest extends AbstractBaseServiceAdapterTest {
       checkProjectKeyExists.apply(new ArrayList<>());
       fail();
     } catch (AdapterException e) {
-      Assert.assertEquals(ioException, e.getCause());
+      assertEquals(ioException, e.getCause());
     }
 
     // Case error, project key exists!
@@ -298,8 +290,8 @@ public class ConfluenceAdapterTest extends AbstractBaseServiceAdapterTest {
 
     when(restClient.execute(isNotNull(), anyBoolean())).thenReturn(response);
     List<CheckPreconditionFailure> newResult = checkProjectKeyExists.apply(new ArrayList<>());
-    Assert.assertEquals(1, newResult.size());
-    Assert.assertTrue(
+    assertEquals(1, newResult.size());
+    assertTrue(
         newResult
             .get(0)
             .toString()
@@ -311,6 +303,6 @@ public class ConfluenceAdapterTest extends AbstractBaseServiceAdapterTest {
     when(restClient.execute(isNotNull())).thenThrow(notFound);
     checkProjectKeyExists = spyAdapter.createProjectKeyExistsCheck(thisProjectKeyNotExists);
     newResult = checkProjectKeyExists.apply(new ArrayList<>());
-    Assert.assertEquals(0, newResult.size());
+    assertEquals(0, newResult.size());
   }
 }

--- a/src/test/java/org/opendevstack/provision/services/CrowdProjectIdentityMgmtAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/CrowdProjectIdentityMgmtAdapterTest.java
@@ -14,25 +14,22 @@
 
 package org.opendevstack.provision.services;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import com.atlassian.crowd.integration.soap.SOAPGroup;
 import com.atlassian.crowd.integration.soap.SOAPPrincipal;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.opendevstack.provision.adapter.exception.IdMgmtException;
 import org.opendevstack.provision.authentication.crowd.CrowdAuthenticationManager;
 import org.opendevstack.provision.model.OpenProjectData;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(SpringExtension.class)
 public class CrowdProjectIdentityMgmtAdapterTest {
 
   @Mock CrowdAuthenticationManager manager;
@@ -73,17 +70,20 @@ public class CrowdProjectIdentityMgmtAdapterTest {
     assertEquals(group.getName(), idMgr.createReadonlyGroup(group.getName()));
   }
 
-  @Test(expected = IdMgmtException.class)
-  public void testCreateNullGroup() throws Exception {
-    idMgr.createGroupInternal(null);
+  @Test
+  public void testCreateNullGroup() {
+    assertThrows(IdMgmtException.class, () -> idMgr.createGroupInternal(null));
   }
 
-  @Test(expected = IdMgmtException.class)
-  public void testCreateGroupSOAPErr() throws Exception {
-    SOAPGroup group = new SOAPGroup("xxx", null);
-
-    when(manager.addGroup(group.getName())).thenThrow(IdMgmtException.class);
-    idMgr.createGroupInternal(group.getName());
+  @Test
+  public void testCreateGroupSOAPErr() {
+    assertThrows(
+        IdMgmtException.class,
+        () -> {
+          SOAPGroup group = new SOAPGroup("xxx", null);
+          when(manager.addGroup(group.getName())).thenThrow(IdMgmtException.class);
+          idMgr.createGroupInternal(group.getName());
+        });
   }
 
   @Test

--- a/src/test/java/org/opendevstack/provision/services/JiraAdapterMT.java
+++ b/src/test/java/org/opendevstack/provision/services/JiraAdapterMT.java
@@ -1,9 +1,7 @@
 package org.opendevstack.provision.services;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opendevstack.provision.SpringBoot;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.opendevstack.provision.adapter.IServiceAdapter.LIFECYCLE_STAGE;
 import org.opendevstack.provision.model.OpenProjectData;
 import org.opendevstack.provision.storage.LocalStorage;
@@ -11,12 +9,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = SpringBoot.class)
-@ActiveProfiles("oauth2,oauth2private")
-@Ignore("Only exists for manual execution")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"oauth2", "oauth2private"})
+@Disabled("Only exists for manual execution")
 public class JiraAdapterMT {
 
   @Autowired private JiraAdapter jiraAdapter;

--- a/src/test/java/org/opendevstack/provision/services/JiraAdapterTests.java
+++ b/src/test/java/org/opendevstack/provision/services/JiraAdapterTests.java
@@ -15,11 +15,9 @@
 package org.opendevstack.provision.services;
 
 import static java.util.Arrays.asList;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.Mockito.*;
@@ -36,14 +34,10 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.*;
 import java.util.function.Function;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.opendevstack.provision.SpringBoot;
 import org.opendevstack.provision.adapter.IODSAuthnzAdapter;
 import org.opendevstack.provision.adapter.ISCMAdapter.URL_TYPE;
 import org.opendevstack.provision.adapter.exception.AdapterException;
@@ -69,17 +63,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @DirtiesContext
 @ActiveProfiles("utest")
 public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
@@ -123,7 +114,7 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
   @Qualifier("projectTemplateKeyNames")
   private List<String> projectTemplateKeyNames;
 
-  @Before
+  @BeforeEach
   public void initTests() {
     objectMapper = new ObjectMapper();
 
@@ -225,8 +216,8 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
                 .method(HttpMethod.GET))
         .thenReturn(returnValue);
 
-    boolean exists = jiraAdapter.projectKeyExists(existingKey);
-    assertThat("expecting key " + existingKey + " exists", exists, CoreMatchers.equalTo(true));
+    assertTrue(
+        jiraAdapter.projectKeyExists(existingKey), "expecting key " + existingKey + " exists");
   }
 
   public List<JsonNode> createResult(String existingKey) {
@@ -477,9 +468,9 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
       fail();
 
     } catch (CreateProjectPreconditionException e) {
-      Assert.assertTrue(e.getCause().getCause().getMessage().contains(ioException.getMessage()));
-      Assert.assertTrue(e.getMessage().contains(JiraAdapter.ADAPTER_NAME));
-      Assert.assertTrue(e.getMessage().contains(project.projectKey));
+      assertTrue(e.getCause().getCause().getMessage().contains(ioException.getMessage()));
+      assertTrue(e.getMessage().contains(JiraAdapter.ADAPTER_NAME));
+      assertTrue(e.getMessage().contains(project.projectKey));
     }
 
     NullPointerException npe = new NullPointerException("npe throw in unit test");
@@ -490,8 +481,8 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
       fail();
 
     } catch (CreateProjectPreconditionException e) {
-      Assert.assertTrue(e.getMessage().contains("Unexpected error"));
-      Assert.assertTrue(e.getMessage().contains(project.projectKey));
+      assertTrue(e.getMessage().contains("Unexpected error"));
+      assertTrue(e.getMessage().contains(project.projectKey));
     }
   }
 
@@ -522,7 +513,7 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
       checkUser.apply(result);
       fail();
     } catch (Exception e) {
-      Assert.assertTrue(IllegalArgumentException.class.isInstance(e));
+      assertTrue(IllegalArgumentException.class.isInstance(e));
     }
 
     // Case IOException throw from rest client!
@@ -532,26 +523,26 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
       checkUser.apply(result);
       fail();
     } catch (AdapterException e) {
-      Assert.assertEquals(ioException, e.getCause());
+      assertEquals(ioException, e.getCause());
     }
 
     // Case no error, user exists!
     when(restClient.execute(isNotNull())).thenReturn(response);
     List<CheckPreconditionFailure> newResult = checkUser.apply(result);
-    Assert.assertEquals(0, newResult.size());
+    assertEquals(0, newResult.size());
 
     // Case no error, username in json response is different than key but equals to emailAddress,
     // user exists!
     when(restClient.execute(isNotNull())).thenReturn(response);
     newResult = spyAdapter.createProjectAdminUserExistsCheck(user + "@domain.com").apply(result);
-    Assert.assertEquals(0, newResult.size());
+    assertEquals(0, newResult.size());
 
     // Case error, user does not exists!
     String thisUserDoesNotExists = "this_cd_user_not_exist";
     checkUser = spyAdapter.createProjectAdminUserExistsCheck(thisUserDoesNotExists);
     newResult = checkUser.apply(result);
-    Assert.assertEquals(1, newResult.size());
-    Assert.assertTrue(newResult.get(0).toString().contains(thisUserDoesNotExists));
+    assertEquals(1, newResult.size());
+    assertTrue(newResult.get(0).toString().contains(thisUserDoesNotExists));
   }
 
   @Test
@@ -578,7 +569,7 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
       checkPermissionScheme.apply(new ArrayList<>());
       fail();
     } catch (Exception e) {
-      Assert.assertTrue(IllegalArgumentException.class.isInstance(e));
+      assertTrue(IllegalArgumentException.class.isInstance(e));
     }
 
     // Case IOException throw from rest client!
@@ -588,19 +579,19 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
       checkPermissionScheme.apply(new ArrayList<>());
       fail();
     } catch (AdapterException e) {
-      Assert.assertEquals(ioException, e.getCause());
+      assertEquals(ioException, e.getCause());
     }
 
     // Case no error, permission scheme id exists!
     when(restClient.execute(isNotNull())).thenReturn(response);
     result = checkPermissionScheme.apply(new ArrayList<>());
-    Assert.assertEquals(0, result.size());
+    assertEquals(0, result.size());
 
     // Case project is not enabled with special permission set
     project.setSpecialPermissionSet(false);
     when(restClient.execute(isNotNull())).thenReturn(response);
     result = checkPermissionScheme.apply(new ArrayList<>());
-    Assert.assertEquals(0, result.size());
+    assertEquals(0, result.size());
 
     // Case error, permission schemed does not exists!
     project.setSpecialPermissionSet(true);
@@ -612,8 +603,8 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
                 404,
                 "Permission scheme " + project.getSpecialPermissionSchemeId() + " does not exist"));
     result = checkPermissionScheme.apply(new ArrayList<>());
-    Assert.assertEquals(1, result.size());
-    Assert.assertTrue(result.get(0).toString().contains(unexistantSchemeId.toString()));
+    assertEquals(1, result.size());
+    assertTrue(result.get(0).toString().contains(unexistantSchemeId.toString()));
   }
 
   @Test
@@ -644,7 +635,7 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
       checkRole.apply(new ArrayList<>());
       fail();
     } catch (Exception e) {
-      Assert.assertTrue(IllegalArgumentException.class.isInstance(e));
+      assertTrue(IllegalArgumentException.class.isInstance(e));
     }
 
     // Case IOException throw from rest client!
@@ -654,21 +645,21 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
       checkRole.apply(new ArrayList<>());
       fail();
     } catch (AdapterException e) {
-      Assert.assertEquals(ioException, e.getCause());
+      assertEquals(ioException, e.getCause());
     }
 
     // Case no error, project role id exists!
     reset(restClient);
     when(restClient.execute(isNotNull())).thenReturn(response);
     result = checkRole.apply(new ArrayList<>());
-    Assert.assertEquals(0, result.size());
+    assertEquals(0, result.size());
     verify(restClient, times(3)).execute(isNotNull());
 
     // Case project is not enabled with special permission set
     project.setSpecialPermissionSet(false);
     when(restClient.execute(isNotNull())).thenReturn(response);
     result = checkRole.apply(new ArrayList<>());
-    Assert.assertEquals(0, result.size());
+    assertEquals(0, result.size());
 
     // Case error: project roles does not exists
     project.setSpecialPermissionSet(true);
@@ -676,8 +667,8 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
     project.setProjectRoleForUserGroup(null);
     project.setProjectRoleForReadonlyGroup(null);
     result = checkRole.apply(new ArrayList<>());
-    Assert.assertEquals(3, result.size());
-    Assert.assertTrue(
+    assertEquals(3, result.size());
+    assertTrue(
         result
             .toArray()[0]
             .toString()
@@ -690,7 +681,7 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
     project.setProjectRoleForReadonlyGroup("99999");
     when(restClient.execute(isNotNull())).thenThrow(new HttpException(404, "Not found!"));
     result = checkRole.apply(new ArrayList<>());
-    Assert.assertEquals(3, result.size());
+    assertEquals(3, result.size());
   }
 
   @Test
@@ -713,7 +704,7 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
       checkGroupExists.apply(result);
       fail();
     } catch (Exception e) {
-      Assert.assertTrue(IllegalArgumentException.class.isInstance(e));
+      assertTrue(IllegalArgumentException.class.isInstance(e));
     }
 
     // Case IOException throw from rest client!
@@ -723,7 +714,7 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
       checkGroupExists.apply(result);
       fail();
     } catch (AdapterException e) {
-      Assert.assertEquals(ioException, e.getCause());
+      assertEquals(ioException, e.getCause());
     }
 
     // Case no error, group exists!
@@ -735,14 +726,14 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
 
     when(restClient.execute(isNotNull())).thenReturn(response);
     List<CheckPreconditionFailure> newResult = checkGroupExists.apply(result);
-    Assert.assertEquals(0, newResult.size());
+    assertEquals(0, newResult.size());
 
     // Case error, user does not exists!
     String thisGroupDoesNotExists = "this_group_does_not_exists".toUpperCase();
     checkGroupExists = spyAdapter.createProjectAdminUserExistsCheck(thisGroupDoesNotExists);
     newResult = checkGroupExists.apply(result);
-    Assert.assertEquals(1, newResult.size());
-    Assert.assertTrue(newResult.get(0).toString().contains(thisGroupDoesNotExists));
+    assertEquals(1, newResult.size());
+    assertTrue(newResult.get(0).toString().contains(thisGroupDoesNotExists));
   }
 
   @Test
@@ -765,7 +756,7 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
       check.apply(new ArrayList<>());
       fail();
     } catch (Exception e) {
-      Assert.assertTrue(IllegalArgumentException.class.isInstance(e));
+      assertTrue(IllegalArgumentException.class.isInstance(e));
     }
 
     // Case IOException throw from rest client!
@@ -775,7 +766,7 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
       check.apply(new ArrayList<>());
       fail();
     } catch (AdapterException e) {
-      Assert.assertEquals(ioException, e.getCause());
+      assertEquals(ioException, e.getCause());
     }
 
     // Case have and not permission!
@@ -791,7 +782,7 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
                 when(restClient.execute(isNotNull())).thenReturn(response);
                 List<CheckPreconditionFailure> newResult = check.apply(new ArrayList<>());
 
-                Assert.assertEquals("true".equals(expected) ? 0 : 1, newResult.size());
+                assertEquals("true".equals(expected) ? 0 : 1, newResult.size());
 
               } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -807,7 +798,7 @@ public class JiraAdapterTests extends AbstractBaseServiceAdapterTest {
 
     when(restClient.execute(isNotNull())).thenReturn(response);
     List<CheckPreconditionFailure> newResult = check.apply(new ArrayList<>());
-    Assert.assertEquals(1, newResult.size());
+    assertEquals(1, newResult.size());
   }
 
   @Test

--- a/src/test/java/org/opendevstack/provision/services/MailAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/MailAdapterTest.java
@@ -14,31 +14,26 @@
 
 package org.opendevstack.provision.services;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 
 import javax.mail.internet.MimeMessage;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.opendevstack.provision.SpringBoot;
 import org.opendevstack.provision.authentication.crowd.CrowdAuthenticationManager;
 import org.opendevstack.provision.model.OpenProjectData;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @DirtiesContext
 @ActiveProfiles("crowd")
 public class MailAdapterTest {
@@ -48,7 +43,7 @@ public class MailAdapterTest {
 
   @Autowired CrowdAuthenticationManager manager;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     mailAdapter.manager = manager;

--- a/src/test/java/org/opendevstack/provision/services/StorageAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/StorageAdapterTest.java
@@ -14,34 +14,29 @@
 
 package org.opendevstack.provision.services;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.opendevstack.provision.SpringBoot;
 import org.opendevstack.provision.authentication.TestAuthentication;
 import org.opendevstack.provision.model.OpenProjectData;
 import org.opendevstack.provision.storage.LocalStorage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.context.WebApplicationContext;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @DirtiesContext
 @ActiveProfiles("utest")
 public class StorageAdapterTest {
@@ -52,7 +47,7 @@ public class StorageAdapterTest {
 
   @Autowired StorageAdapter adapter;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
   }

--- a/src/test/java/org/opendevstack/provision/services/jira/FullJiraProjectFactoryTest.java
+++ b/src/test/java/org/opendevstack/provision/services/jira/FullJiraProjectFactoryTest.java
@@ -13,14 +13,12 @@
  */
 package org.opendevstack.provision.services.jira;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.opendevstack.provision.services.jira.JiraSpecialPermissionerTest.UTEST_CONFIGURED_PERMISSION_SCHEME_ID;
 import static org.opendevstack.provision.services.jira.JiraSpecialPermissionerTest.UTEST_PROJECT_TEMPLATE_NAME;
 
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opendevstack.provision.SpringBoot;
+import org.junit.jupiter.api.Test;
 import org.opendevstack.provision.model.OpenProjectData;
 import org.opendevstack.provision.model.jira.FullJiraProject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,10 +26,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @DirtiesContext
 @ActiveProfiles("utest")
 public class FullJiraProjectFactoryTest {

--- a/src/test/java/org/opendevstack/provision/services/jira/JiraProjectPropertyUpdaterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/jira/JiraProjectPropertyUpdaterTest.java
@@ -1,23 +1,19 @@
 package org.opendevstack.provision.services.jira;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
-import org.opendevstack.provision.SpringBoot;
 import org.opendevstack.provision.util.rest.RestClient;
 import org.opendevstack.provision.util.rest.RestClientCall;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @ActiveProfiles("utest")
 public class JiraProjectPropertyUpdaterTest {
 

--- a/src/test/java/org/opendevstack/provision/services/jira/JiraProjectTypePropertyCalculatorTest.java
+++ b/src/test/java/org/opendevstack/provision/services/jira/JiraProjectTypePropertyCalculatorTest.java
@@ -13,22 +13,18 @@
  */
 package org.opendevstack.provision.services.jira;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
-import org.opendevstack.provision.SpringBoot;
 import org.opendevstack.provision.services.JiraAdapter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @ActiveProfiles("utest")
 public class JiraProjectTypePropertyCalculatorTest {
 
@@ -41,7 +37,7 @@ public class JiraProjectTypePropertyCalculatorTest {
 
   @Autowired private JiraProjectTypePropertyCalculator propertyCalculator;
 
-  @Before
+  @BeforeEach
   public void beforeTest() {
     MockitoAnnotations.initMocks(this);
   }

--- a/src/test/java/org/opendevstack/provision/services/jira/JiraSpecialPermissionerTest.java
+++ b/src/test/java/org/opendevstack/provision/services/jira/JiraSpecialPermissionerTest.java
@@ -21,9 +21,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.function.Consumer;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opendevstack.provision.SpringBoot;
+import org.junit.jupiter.api.Test;
 import org.opendevstack.provision.model.OpenProjectData;
 import org.opendevstack.provision.model.jira.PermissionScheme;
 import org.opendevstack.provision.util.rest.RestClient;
@@ -33,10 +31,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @DirtiesContext
 @ActiveProfiles("utest")
 public class JiraSpecialPermissionerTest {

--- a/src/test/java/org/opendevstack/provision/services/jira/WebhookProxyJiraPropertyUpdaterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/jira/WebhookProxyJiraPropertyUpdaterTest.java
@@ -13,26 +13,22 @@
  */
 package org.opendevstack.provision.services.jira;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.net.URL;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opendevstack.provision.SpringBoot;
+import org.junit.jupiter.api.Test;
 import org.opendevstack.provision.services.JiraAdapter;
 import org.opendevstack.provision.services.webhookproxy.WebhookProxyUrlFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @ActiveProfiles("utest")
 public class WebhookProxyJiraPropertyUpdaterTest {
 

--- a/src/test/java/org/opendevstack/provision/services/openshift/OpenshiftClientTest.java
+++ b/src/test/java/org/opendevstack/provision/services/openshift/OpenshiftClientTest.java
@@ -13,7 +13,7 @@
  */
 package org.opendevstack.provision.services.openshift;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -21,13 +21,13 @@ import com.openshift.restclient.IClient;
 import com.openshift.restclient.model.IResource;
 import java.util.List;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class OpenshiftClientTest {
 
   @MockBean private IClient ocClient;
@@ -36,7 +36,7 @@ public class OpenshiftClientTest {
 
   private OpenshiftClient openshiftClient;
 
-  @Before
+  @BeforeEach
   public void setup() {
     openshiftClient = new OpenshiftClient(url, ocClient);
   }

--- a/src/test/java/org/opendevstack/provision/services/openshift/OpenshiftServiceTest.java
+++ b/src/test/java/org/opendevstack/provision/services/openshift/OpenshiftServiceTest.java
@@ -13,15 +13,13 @@
  */
 package org.opendevstack.provision.services.openshift;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opendevstack.provision.SpringBoot;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.opendevstack.provision.adapter.exception.AdapterException;
 import org.opendevstack.provision.adapter.exception.CreateProjectPreconditionException;
 import org.opendevstack.provision.controller.CheckPreconditionFailure;
@@ -31,10 +29,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @DirtiesContext
 @ActiveProfiles("utest")
 public class OpenshiftServiceTest {
@@ -43,7 +39,7 @@ public class OpenshiftServiceTest {
 
   @Autowired private OpenshiftService openshiftService;
 
-  @Before
+  @BeforeEach
   public void setup() {
     openshiftService = new OpenshiftService(openshiftClient);
   }

--- a/src/test/java/org/opendevstack/provision/services/webhookproxy/WebhookProxyUrlFactoryTest.java
+++ b/src/test/java/org/opendevstack/provision/services/webhookproxy/WebhookProxyUrlFactoryTest.java
@@ -13,21 +13,17 @@
  */
 package org.opendevstack.provision.services.webhookproxy;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opendevstack.provision.SpringBoot;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @ActiveProfiles("utest")
 public class WebhookProxyUrlFactoryTest {
 

--- a/src/test/java/org/opendevstack/provision/storage/LocalStorageTest.java
+++ b/src/test/java/org/opendevstack/provision/storage/LocalStorageTest.java
@@ -34,9 +34,6 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.FileCopyUtils;
 
-@SpringBootTest
-@DirtiesContext
-@ActiveProfiles("utest")
 public class LocalStorageTest {
 
   private LocalStorage localStorage;

--- a/src/test/java/org/opendevstack/provision/storage/LocalStorageTest.java
+++ b/src/test/java/org/opendevstack/provision/storage/LocalStorageTest.java
@@ -14,11 +14,7 @@
 
 package org.opendevstack.provision.storage;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -26,24 +22,19 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opendevstack.provision.SpringBoot;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.opendevstack.provision.adapter.ISCMAdapter.URL_TYPE;
 import org.opendevstack.provision.model.AboutChangesData;
 import org.opendevstack.provision.model.OpenProjectData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.FileCopyUtils;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.MOCK, classes = SpringBoot.class)
+@SpringBootTest
 @DirtiesContext
 @ActiveProfiles("utest")
 public class LocalStorageTest {
@@ -52,16 +43,20 @@ public class LocalStorageTest {
 
   private static final Logger logger = LoggerFactory.getLogger(LocalStorageTest.class);
 
-  @Before
+  @BeforeEach
   public void setUp() {
     localStorage = new LocalStorage();
     localStorage.setLocalStoragePath("src/test/resources/");
   }
 
-  @Test(expected = IOException.class)
-  public void storeProjectNoKey() throws Exception {
-    OpenProjectData project = new OpenProjectData();
-    localStorage.storeProject(project);
+  @Test
+  public void storeProjectNoKey() {
+    assertThrows(
+        IOException.class,
+        () -> {
+          OpenProjectData project = new OpenProjectData();
+          localStorage.storeProject(project);
+        });
   }
 
   @Test
@@ -130,11 +125,15 @@ public class LocalStorageTest {
     (new File(filePath)).delete();
   }
 
-  @Test(expected = IOException.class)
-  public void storeProjectWithException() throws Exception {
-    OpenProjectData project = new OpenProjectData();
-    localStorage.setLocalStoragePath("/to/some/non/existant/folder/");
-    localStorage.storeProject(project);
+  @Test
+  public void storeProjectWithException() {
+    assertThrows(
+        IOException.class,
+        () -> {
+          OpenProjectData project = new OpenProjectData();
+          localStorage.setLocalStoragePath("/to/some/non/existant/folder/");
+          localStorage.storeProject(project);
+        });
   }
 
   @Test

--- a/src/test/java/org/opendevstack/provision/storage/LocalStorageTest.java
+++ b/src/test/java/org/opendevstack/provision/storage/LocalStorageTest.java
@@ -29,9 +29,6 @@ import org.opendevstack.provision.model.AboutChangesData;
 import org.opendevstack.provision.model.OpenProjectData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.FileCopyUtils;
 
 public class LocalStorageTest {

--- a/src/test/java/org/opendevstack/provision/util/GitUrlWranglerTest.java
+++ b/src/test/java/org/opendevstack/provision/util/GitUrlWranglerTest.java
@@ -1,11 +1,11 @@
 package org.opendevstack.provision.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.UnsupportedEncodingException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GitUrlWranglerTest {
   private GitUrlWrangler urlWrangler = new GitUrlWrangler();

--- a/src/test/java/org/opendevstack/provision/util/RestClientCallArgumentMatcherTest.java
+++ b/src/test/java/org/opendevstack/provision/util/RestClientCallArgumentMatcherTest.java
@@ -1,13 +1,11 @@
 package org.opendevstack.provision.util;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.opendevstack.provision.util.RestClientCallArgumentMatcher.matchesClientCall;
 import static org.opendevstack.provision.util.rest.RestClientCall.get;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.opendevstack.provision.util.rest.RestClientCall;
 
 public class RestClientCallArgumentMatcherTest {
@@ -16,20 +14,20 @@ public class RestClientCallArgumentMatcherTest {
   public void matchesURLWithEquals() {
     String url = "https://www.opitz-consulting.com/index.html";
     RestClientCall given = get().url(url);
-    assertThatMatches(given, matchesClientCall().url(url));
+    assertTrue(matchesClientCall().url(url).matches(given));
   }
 
   @Test
   public void matchesURLWithMatcher() {
     String url = "https://www.opitz-consulting.com/index.html";
     RestClientCall given = get().url(url);
-    assertThatMatches(given, matchesClientCall().url(containsString("opitz")));
+    assertTrue(matchesClientCall().url(containsString("opitz")).matches(given));
   }
 
   @Test
   public void matchesQueryParams() {
     RestClientCall given = get().queryParam("p1", "v1").queryParam("p2", "v2");
-    assertThatMatches(given, matchesClientCall().queryParam("p1", "v1"));
+    assertTrue(matchesClientCall().queryParam("p1", "v1").matches(given));
   }
 
   @Test
@@ -39,22 +37,18 @@ public class RestClientCallArgumentMatcherTest {
     ValueCaptor<Object> bodyValueHolder = new ValueCaptor<>();
 
     RestClientCall given = get().url("https://www.opitz-consulting.com/index.html").body(42);
-    assertThatMatches(
-        given,
+    assertTrue(
         matchesClientCall()
             .url(containsString("opitz"))
             .urlCaptor(urlValueHolder)
             .bodyEqualTo(given.getBody())
-            .bodyCaptor(bodyValueHolder));
+            .bodyCaptor(bodyValueHolder)
+            .matches(given));
 
-    assertThat(
-        "given value is returned for url",
-        urlValueHolder.getValues().get(0),
-        equalTo(given.getUrl()));
-    assertThat(
-        "given value is returned for body",
-        bodyValueHolder.getValues().get(0),
-        equalTo(given.getBody()));
+    assertEquals(
+        given.getUrl(), urlValueHolder.getValues().get(0), "given value is returned for url");
+    assertEquals(
+        given.getBody(), bodyValueHolder.getValues().get(0), "given value is returned for body");
   }
 
   @Test
@@ -72,20 +66,13 @@ public class RestClientCallArgumentMatcherTest {
             .bodyEqualTo("the answer to life the universe and everything") // does not match
             .bodyCaptor(bodyValueHolder);
 
-    assertThat(
-        "matcher is expected to not match, but it matched", matcher.matches(given), equalTo(false));
+    assertFalse(matcher.matches(given), "matcher is expected to not match, but it matched");
 
     // check that no value if captured at all, because at least one property is not valid according
     // to matcher
 
-    assertThat("expected no value was captured for url", urlValueHolder.getValues(), hasSize(0));
+    assertTrue(urlValueHolder.getValues().isEmpty(), "expected no value was captured for url");
 
-    assertThat("expected no value was captured for body", bodyValueHolder.getValues(), hasSize(0));
-  }
-
-  public void assertThatMatches(RestClientCall given, RestClientCallArgumentMatcher matcher) {
-    boolean matches = matcher.matches(given);
-    // assertThat(String.format("Matcher %s should match",matcher), matches, equalTo(true));
-    assertThat("PRÜFEN " + matcher.toString(), matches, equalTo(true));
+    assertTrue(bodyValueHolder.getValues().isEmpty(), "expected no value was captured for body");
   }
 }

--- a/src/test/java/org/opendevstack/provision/util/rest/RestClientTest.java
+++ b/src/test/java/org/opendevstack/provision/util/rest/RestClientTest.java
@@ -14,20 +14,15 @@
 
 package org.opendevstack.provision.util.rest;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opendevstack.provision.SpringBoot;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.opendevstack.provision.authentication.crowd.CrowdAuthenticationManager;
 import org.opendevstack.provision.util.CredentialsInfo;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,10 +31,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = SpringBoot.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext
 @ActiveProfiles("crowd")
 public class RestClientTest {
@@ -51,17 +44,17 @@ public class RestClientTest {
 
   @Autowired CrowdAuthenticationManager manager;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     client = new RestClient();
     client.setConnectTimeout(5);
-    client.setReadTimeout(5);
+    client.setReadTimeout(20);
     client.afterPropertiesSet();
   }
 
   @Test
   public void getClient() {
-    Assert.assertThat(client.getClient(), instanceOf(OkHttpClient.class));
+    assertTrue(client.getClient() instanceof OkHttpClient);
   }
 
   @Test
@@ -76,9 +69,9 @@ public class RestClientTest {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void callHttpMissingUrl() throws Exception {
-    client.execute(validGetCall().url(null));
+  @Test
+  public void callHttpMissingUrl() {
+    assertThrows(IllegalArgumentException.class, () -> client.execute(validGetCall().url(null)));
   }
 
   @Test

--- a/src/test/java/org/opendevstack/provision/util/rest/RestClientTest.java
+++ b/src/test/java/org/opendevstack/provision/util/rest/RestClientTest.java
@@ -48,7 +48,7 @@ public class RestClientTest {
   public void setUp() {
     client = new RestClient();
     client.setConnectTimeout(5);
-    client.setReadTimeout(20);
+    client.setReadTimeout(25);
     client.afterPropertiesSet();
   }
 


### PR DESCRIPTION
Relates to #638
In this PR the most prominent thing I did is to raise the versions of 
```
org.springframework.boot to version '2.4.0'
io.spring.dependency-management to version '1.0.10.RELEASE'
```
Other notable things in this PR:
- Current spring boot versions are using Junit5 instead of 4. There were many changes from Junit 4 to 5 and hence I had to migrate **all** test classes. 
- Simplified the nexus + repo part in build.gradle a bit.
- Changed the `--spring.config.additional-location` spring option in Dockerfile by removing `config/*/` (according to [doc ](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files-wildcards) this is considered by default) and adding `optional:file:` to jira template because the behaviour changed apparently that an exception is now thrown if a file is not existing and not declared as optional.
Here I have the remaining questions if we also should make `quickstarter.properties` optional and if we can remove the javadoc above it because it is wrong (this additional-location option does not override, it adds properties).


So far, I deployed this in one of our ODS installations (in which crowd is used for auth). I was able to create a new component in an existing project. I am now not sure how to approach further testing to be sure it will work in other envs (e.g. that use azure for auth).