### PR TITLE
Feature/update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ gradle.properties
 /src/main/resources/__application.properties
 /src/main/resources/application-oauth2private.properties
 /src/main/resources/application-testods.properties
+/src/main/resources/application-local.properties
 
 /src/main/resources/history-local/
 

--- a/build.gradle
+++ b/build.gradle
@@ -74,13 +74,13 @@ dependencies {
     testImplementation('org.springframework.restdocs:spring-restdocs-mockmvc')
     testImplementation('org.springframework.security:spring-security-test')
 
-    implementation("org.thymeleaf.extras:thymeleaf-extras-springsecurity5")
+    implementation('org.thymeleaf.extras:thymeleaf-extras-springsecurity5')
 
     // oauth2
-    implementation 'org.springframework.security:spring-security-oauth2-core'
-    implementation 'org.springframework.security:spring-security-oauth2-client'
-    implementation 'org.springframework.security:spring-security-oauth2-jose'
-    implementation 'org.springframework.security.oauth:spring-security-oauth2:2.5.0.RELEASE'
+    implementation('org.springframework.security:spring-security-oauth2-core')
+    implementation('org.springframework.security:spring-security-oauth2-client')
+    implementation('org.springframework.security:spring-security-oauth2-jose')
+    implementation('org.springframework.security.oauth:spring-security-oauth2:2.5.0.RELEASE')
 
     implementation(group: 'com.openshift', name: 'openshift-restclient-java', version: '9.0.1.Final') {
         exclude(group: 'org.slf4j', module: 'slf4j-api:')
@@ -91,34 +91,36 @@ dependencies {
     runtimeOnly('com.microsoft.azure:azure-active-directory-spring-boot-starter:2.3.5')
 
     //frontend webjars
-    implementation 'org.webjars:webjars-locator:0.37'
-    implementation 'org.webjars.bower:jquery:3.4.1'
-    implementation 'org.webjars.bower:bootstrap:3.3.7'
-    implementation 'org.webjars.bower:react:16.1.0'
-    implementation 'org.webjars.bower:font-awesome:4.7.0'
-    implementation 'org.webjars.bower:lodash:4.17.10'
+    implementation('org.webjars:webjars-locator:0.37')
+    implementation('org.webjars.bower:jquery:3.4.1')
+    implementation('org.webjars.bower:bootstrap:3.3.7')
+    implementation('org.webjars.bower:react:16.1.0')
+    implementation('org.webjars.bower:font-awesome:4.7.0')
+    implementation('org.webjars.bower:lodash:4.17.10')
 
     //encryption library for properties
-    implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:2.1.2'
+    implementation('com.github.ulisesbocchio:jasypt-spring-boot-starter:2.1.2')
 
     //easy http calls to atlassian JSON APIs
-    implementation "com.squareup.okhttp3:okhttp:4.9.0"
+    implementation('com.squareup.okhttp3:okhttp:4.9.0')
 
+    implementation(group: 'commons-httpclient', name: 'commons-httpclient', version: '3.1')
+    implementation(group: 'com.atlassian.security', name: 'atlassian-cookie-tools', version: '3.2.14')
     implementation(group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final')
     implementation(group: 'com.atlassian.crowd', name: 'crowd-integration-springsecurity', version: '1000.82.0') {
-        exclude group: 'commons-httpclient'
-        exclude group: 'org.apache.ws.commons', module: 'XmlSchema'
+        exclude(group: 'commons-httpclient')
+        exclude(group: 'org.apache.ws.commons', module: 'XmlSchema')
         // Explicitly excludes vulnerable versions
-        exclude group: 'org.apache.struts', module: 'struts2-core'
-        exclude group: 'org.apache.struts.xwork', module: 'xwork-core'
-        exclude group: 'commons-collections', module: 'commons-collections'
-        exclude group: 'commons-fileupload', module: 'commons-fileupload'
-        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
-        exclude group: 'org.aspectj', module: 'aspectjweaver'
-        exclude group: 'com.google.guava', module: 'guava'
+        exclude(group: 'org.apache.struts', module: 'struts2-core')
+        exclude(group: 'org.apache.struts.xwork', module: 'xwork-core')
+        exclude(group: 'commons-collections', module: 'commons-collections')
+        exclude(group: 'commons-fileupload', module: 'commons-fileupload')
+        exclude(group: 'com.fasterxml.jackson.core', module: 'jackson-databind')
+        exclude(group: 'org.aspectj', module: 'aspectjweaver')
+        exclude(group: 'com.google.guava', module: 'guava')
     }
     // latest version of excluded libs: refactor this when upgrading to new 'com.atlassian.crowd:crowd-integration-springsecurity'
-    implementation group: 'com.google.guava', name: 'guava', version: '30.0-jre'
+    implementation(group: 'com.google.guava', name: 'guava', version: '30.0-jre')
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
 }
 
 plugins {
-    id 'org.springframework.boot' version '2.4.0'
+    id 'org.springframework.boot' version '2.4.1'
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
     id 'java'
     id 'maven-publish'

--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,7 @@ bootRun {
         }
     }
     args = [
-            '--spring.config.location=file:./build/resources/main/application-rene.properties'
+            '--spring.config.location=file:./build/resources/main/application-local.properties'
     ]
 }
 
@@ -190,4 +190,4 @@ task yarnBuild(type:Exec) {
     commandLine 'yarn', 'build'
 }
 
-//bootRun.dependsOn yarnBuild
+bootRun.dependsOn yarnBuild

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ plugins {
     id 'jacoco'
     id 'org.sonarqube' version "3.0"
     id "com.diffplug.spotless" version "5.8.2"
+    id "nebula.lint" version "16.9.1"
 }
 
 group = 'prov'
@@ -69,7 +70,6 @@ dependencies {
     runtimeOnly('org.springframework.boot:spring-boot-devtools')
     //hot reloading, disabling cache ...
 
-    annotationProcessor('org.projectlombok:lombok')
     testImplementation('org.springframework.boot:spring-boot-starter-test')
     testImplementation('org.springframework.restdocs:spring-restdocs-mockmvc')
     testImplementation('org.springframework.security:spring-security-test')
@@ -80,16 +80,15 @@ dependencies {
     implementation 'org.springframework.security:spring-security-oauth2-core'
     implementation 'org.springframework.security:spring-security-oauth2-client'
     implementation 'org.springframework.security:spring-security-oauth2-jose'
-    implementation 'org.springframework.security:spring-security-jwt:1.1.0.RELEASE'
-    implementation 'org.springframework.security.oauth:spring-security-oauth2:2.4.0.RELEASE'
+    implementation 'org.springframework.security.oauth:spring-security-oauth2:2.5.0.RELEASE'
 
-    implementation(group: 'com.openshift', name: 'openshift-restclient-java', version: '9.0.0.Final') {
+    implementation(group: 'com.openshift', name: 'openshift-restclient-java', version: '9.0.1.Final') {
         exclude(group: 'org.slf4j', module: 'slf4j-api:')
         exclude(group: 'org.slf4j', module: 'slf4j-log4j12')
     }
 
     // azure ad
-    implementation('com.microsoft.azure:azure-active-directory-spring-boot-starter:2.2.2')
+    runtimeOnly('com.microsoft.azure:azure-active-directory-spring-boot-starter:2.3.5')
 
     //frontend webjars
     implementation 'org.webjars:webjars-locator:0.37'
@@ -100,16 +99,12 @@ dependencies {
     implementation 'org.webjars.bower:lodash:4.17.10'
 
     //encryption library for properties
-    implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:2.1.1'
+    implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:2.1.2'
 
     //easy http calls to atlassian JSON APIs
-    implementation "com.squareup.okhttp3:okhttp:4.4.0"
+    implementation "com.squareup.okhttp3:okhttp:4.9.0"
 
-    implementation group: 'commons-httpclient', name: 'commons-httpclient', version: '3.1'
-    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.10.0.pr3'
-    implementation group: 'joda-time', name: 'joda-time', version: '2.10.4'
     implementation(group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final')
-    implementation(group: 'com.atlassian.security', name: 'atlassian-cookie-tools', version: '3.2.11')
     implementation(group: 'com.atlassian.crowd', name: 'crowd-integration-springsecurity', version: '1000.82.0') {
         exclude group: 'commons-httpclient'
         exclude group: 'org.apache.ws.commons', module: 'XmlSchema'
@@ -123,12 +118,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
     // latest version of excluded libs: refactor this when upgrading to new 'com.atlassian.crowd:crowd-integration-springsecurity'
-    implementation group: 'org.apache.struts', name: 'struts2-core', version: '2.5.20'
-    implementation group: 'org.apache.struts.xwork', name: 'xwork-core', version: '2.3.37'
-    implementation group: 'commons-collections', name: 'commons-collections', version: '3.2.2'
-    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.4'
-    implementation group: 'org.aspectj', name: 'aspectjweaver', version: '1.9.4'
-    implementation group: 'com.google.guava', name: 'guava', version: '23.0'
+    implementation group: 'com.google.guava', name: 'guava', version: '30.0-jre'
 
 }
 
@@ -159,7 +149,7 @@ bootRun {
         }
     }
     args = [
-            '--spring.config.location=file:./build/resources/main/application-local.properties'
+            '--spring.config.location=file:./build/resources/main/application-rene.properties'
     ]
 }
 
@@ -173,7 +163,7 @@ jacocoTestReport {
     }
 }
 
-// run with ./gradlew spotlessApply.
+// run with ./gradlew spotlessApply
 spotless {
     java {
         googleJavaFormat('1.9')
@@ -181,6 +171,12 @@ spotless {
         indentWithSpaces(2)
         endWithNewline()
     }
+}
+
+// run with ./gradlew lintGradle
+gradleLint {
+    alwaysRun = false
+    rules = ['unused-dependency']
 }
 
 task yarnBuild(type:Exec) {
@@ -194,4 +190,4 @@ task yarnBuild(type:Exec) {
     commandLine 'yarn', 'build'
 }
 
-bootRun.dependsOn yarnBuild
+//bootRun.dependsOn yarnBuild

--- a/build.gradle
+++ b/build.gradle
@@ -82,8 +82,8 @@ dependencies {
     implementation('org.springframework.security:spring-security-oauth2-jose')
     implementation('org.springframework.security.oauth:spring-security-oauth2:2.5.0.RELEASE')
 
-    implementation(group: 'com.openshift', name: 'openshift-restclient-java', version: '9.0.1.Final') {
-        exclude(group: 'org.slf4j', module: 'slf4j-api:')
+    implementation('com.openshift:openshift-restclient-java:9.0.1.Final') {
+        exclude(group: 'org.slf4j', module: 'slf4j-api')
         exclude(group: 'org.slf4j', module: 'slf4j-log4j12')
     }
 
@@ -104,10 +104,10 @@ dependencies {
     //easy http calls to atlassian JSON APIs
     implementation('com.squareup.okhttp3:okhttp:4.9.0')
 
-    implementation(group: 'commons-httpclient', name: 'commons-httpclient', version: '3.1')
-    implementation(group: 'com.atlassian.security', name: 'atlassian-cookie-tools', version: '3.2.14')
-    implementation(group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final')
-    implementation(group: 'com.atlassian.crowd', name: 'crowd-integration-springsecurity', version: '1000.82.0') {
+    implementation('commons-httpclient:commons-httpclient:3.1')
+    implementation('com.atlassian.security:atlassian-cookie-tools:3.2.14')
+    implementation('javax.validation:validation-api:2.0.1.Final')
+    implementation('com.atlassian.crowd:crowd-integration-springsecurity:1000.82.0') {
         exclude(group: 'commons-httpclient')
         exclude(group: 'org.apache.ws.commons', module: 'XmlSchema')
         // Explicitly excludes vulnerable versions
@@ -119,8 +119,9 @@ dependencies {
         exclude(group: 'org.aspectj', module: 'aspectjweaver')
         exclude(group: 'com.google.guava', module: 'guava')
     }
+
     // latest version of excluded libs: refactor this when upgrading to new 'com.atlassian.crowd:crowd-integration-springsecurity'
-    implementation(group: 'com.google.guava', name: 'guava', version: '30.0-jre')
+    implementation('com.google.guava:guava:30.0-jre')
 
 }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,4 +20,4 @@ ENTRYPOINT ["entrypoint.sh"]
 # which are defined in classpath:/application.properties
 # for details refert to Spring boot documention:
 # https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config
-CMD ["java", "-jar", "app.jar", "--spring.config.additional-location=/quickstarters/quickstarters.properties,/jira-project-types/additional-templates.properties,/config/*/"]
+CMD ["java", "-jar", "app.jar", "--spring.config.additional-location=/quickstarters/quickstarters.properties,/jira-project-types/additional-templates.properties"]

--- a/src/test/java/org/opendevstack/provision/util/rest/RestClientTest.java
+++ b/src/test/java/org/opendevstack/provision/util/rest/RestClientTest.java
@@ -71,7 +71,7 @@ public class RestClientTest {
 
   @Test
   public void callHttpMissingUrl() {
-    assertThrows(IllegalArgumentException.class, () -> client.execute(validGetCall().url(null)));
+    assertThrows(NullPointerException.class, () -> client.execute(validGetCall().url(null)));
   }
 
   @Test


### PR DESCRIPTION
- I added the nebula-lint gradle plugin to identify unused dependencies
- The change in RestClientTest.java was due to the fact that the latest okhttp version returns nullpointer exception instead of illegalargument, probably due to their migration to kotlin and thus changing the httpurl.parse method

Info: This branch was branched out from feature/update-spring-boot (#645)

