### PR TITLE
refactor tests

### DIFF
--- a/src/main/java/org/opendevstack/provision/services/MailAdapter.java
+++ b/src/main/java/org/opendevstack/provision/services/MailAdapter.java
@@ -67,7 +67,7 @@ public class MailAdapter {
           messageHelper.setFrom(mailSenderAddress);
           messageHelper.setTo(recipient);
           messageHelper.setSubject("ODS Project provision update");
-          messageHelper.setText(build(data), true);
+          messageHelper.setText(buildText(data), true);
         };
 
     Thread sendThread =
@@ -87,7 +87,7 @@ public class MailAdapter {
     logger.debug("Mail for project: {} sent", data.projectKey);
   }
 
-  String build(OpenProjectData data) {
+  private String buildText(OpenProjectData data) {
     try {
       Context context = new Context();
       context.setVariable("project", data);

--- a/src/main/java/org/opendevstack/provision/util/rest/RestClient.java
+++ b/src/main/java/org/opendevstack/provision/util/rest/RestClient.java
@@ -34,11 +34,9 @@ public class RestClient {
 
   @PostConstruct
   public void afterPropertiesSet() {
-
     if (trustAllCertificates) {
       LOG.warn(
-          "Trust all certificates. Only set this property to true in development environment! [restClient.trust-all-certificates={}]",
-          trustAllCertificates);
+          "Trust all certificates. Only set this property to true in development environment! [restClient.trust-all-certificates=true]");
       client = TrustAllCertificatesClientFactory.createClient(connectTimeout, readTimeout);
     } else {
       client = standardClient();
@@ -192,21 +190,12 @@ public class RestClient {
 
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.sslSocketFactory(sslSocketFactory, (X509TrustManager) trustAllCerts[0]);
-        builder.hostnameVerifier(
-            new HostnameVerifier() {
-              @Override
-              public boolean verify(String hostname, SSLSession session) {
-                return true;
-              }
-            });
+        builder.hostnameVerifier((hostname, session) -> true);
 
-        OkHttpClient httpClient =
-            builder
-                .connectTimeout(connectTimeout, TimeUnit.SECONDS)
-                .readTimeout(readTimeout, TimeUnit.SECONDS)
-                .build();
-
-        return httpClient;
+        return builder
+            .connectTimeout(connectTimeout, TimeUnit.SECONDS)
+            .readTimeout(readTimeout, TimeUnit.SECONDS)
+            .build();
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/src/test/java/org/opendevstack/provision/authentication/SimpleCachingGroupMembershipManagerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/SimpleCachingGroupMembershipManagerTest.java
@@ -19,9 +19,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
+/** Testclass for the simple caching manager */
 @SpringBootTest
 @DirtiesContext
-/** Testclass for the simple caching manager */
 @ActiveProfiles("crowd")
 public class SimpleCachingGroupMembershipManagerTest {
 

--- a/src/test/java/org/opendevstack/provision/authentication/SimpleCachingGroupMembershipManagerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/SimpleCachingGroupMembershipManagerTest.java
@@ -19,7 +19,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
-/** Testclass for the simple caching manager */
 @SpringBootTest
 @DirtiesContext
 @ActiveProfiles("crowd")

--- a/src/test/java/org/opendevstack/provision/authentication/crowd/CrowdAuthenticationManagerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/crowd/CrowdAuthenticationManagerTest.java
@@ -53,7 +53,7 @@ public class CrowdAuthenticationManagerTest {
   @SuppressWarnings("squid:S2068")
   static final String TEST_CRED = "test";
 
-  @Autowired CrowdAuthenticationManager manager;
+  @Autowired private CrowdAuthenticationManager manager;
 
   @Mock private SecurityServerClient securityServerClient;
 

--- a/src/test/java/org/opendevstack/provision/authentication/crowd/ProvAppSimpleCachingGroupMembershipManagerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/crowd/ProvAppSimpleCachingGroupMembershipManagerTest.java
@@ -29,7 +29,6 @@ import java.rmi.RemoteException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -42,7 +41,7 @@ public class ProvAppSimpleCachingGroupMembershipManagerTest {
 
   @MockBean private GroupManager groupManager;
 
-  @Mock private BasicCache cache;
+  @MockBean private BasicCache cache;
 
   @Test
   public void getMemberships()

--- a/src/test/java/org/opendevstack/provision/authentication/crowd/ProvAppSimpleCachingGroupMembershipManagerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/crowd/ProvAppSimpleCachingGroupMembershipManagerTest.java
@@ -29,6 +29,7 @@ import java.rmi.RemoteException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -41,7 +42,7 @@ public class ProvAppSimpleCachingGroupMembershipManagerTest {
 
   @MockBean private GroupManager groupManager;
 
-  @MockBean private BasicCache cache;
+  @Mock private BasicCache cache;
 
   @Test
   public void getMemberships()

--- a/src/test/java/org/opendevstack/provision/authentication/oauth2/Oauth2LogoutHandlerLogoutFromIDMTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/oauth2/Oauth2LogoutHandlerLogoutFromIDMTest.java
@@ -27,7 +27,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
     })
 public class Oauth2LogoutHandlerLogoutFromIDMTest {
 
-  @Autowired Oauth2LogoutHandler logoutHandler;
+  @Autowired private Oauth2LogoutHandler logoutHandler;
 
   @MockBean private HttpServletRequest request;
 

--- a/src/test/java/org/opendevstack/provision/authentication/oauth2/Oauth2LogoutHandlerTest.java
+++ b/src/test/java/org/opendevstack/provision/authentication/oauth2/Oauth2LogoutHandlerTest.java
@@ -26,7 +26,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
     })
 public class Oauth2LogoutHandlerTest {
 
-  @Autowired Oauth2LogoutHandler logoutHandler;
+  @Autowired private Oauth2LogoutHandler logoutHandler;
 
   @MockBean private HttpServletRequest request;
   @MockBean private HttpServletResponse response;

--- a/src/test/java/org/opendevstack/provision/config/AuthSecurityTestConfig.java
+++ b/src/test/java/org/opendevstack/provision/config/AuthSecurityTestConfig.java
@@ -16,7 +16,10 @@ package org.opendevstack.provision.config;
 import static java.util.Map.entry;
 import static org.mockito.Mockito.mock;
 
+import com.atlassian.crowd.service.cache.BasicCache;
+import com.atlassian.crowd.service.cache.CacheImpl;
 import java.util.Map;
+import net.sf.ehcache.CacheManager;
 import org.opendevstack.provision.adapter.IODSAuthnzAdapter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.ehcache.EhCacheManagerFactoryBean;
@@ -59,6 +62,18 @@ public class AuthSecurityTestConfig {
   @Primary
   public IODSAuthnzAdapter iodsAuthnzAdapter() {
     return mock(IODSAuthnzAdapter.class);
+  }
+
+  @Bean
+  @Primary
+  public BasicCache getCache() {
+    return new CacheImpl(getCacheManager());
+  }
+
+  @Bean
+  @Primary
+  public CacheManager getCacheManager() {
+    return getEhCacheFactory().getObject();
   }
 
   @Bean

--- a/src/test/java/org/opendevstack/provision/config/AuthSecurityTestConfig.java
+++ b/src/test/java/org/opendevstack/provision/config/AuthSecurityTestConfig.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.opendevstack.provision.config;
+
+import static java.util.Map.entry;
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+import org.opendevstack.provision.adapter.IODSAuthnzAdapter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.ehcache.EhCacheManagerFactoryBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AuthSecurityTestConfig {
+
+  public static final String TEST_USER_USERNAME = "user";
+  public static final String TEST_ADMIN_USERNAME = "admin";
+  public static final String TEST_ADMIN_EMAIL = "admin@example.com";
+  public static final String TEST_NOT_PERMISSIONED_USER_USERNAME = "not-permissioned-user";
+  public static final String TEST_VALID_CREDENTIAL = "validsecret";
+
+  @Value("${idmanager.group.opendevstack-users}")
+  protected String roleUser;
+
+  @Value("${idmanager.group.opendevstack-administrators}")
+  protected String roleAdmin;
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean(name = "testUsersAndRoles")
+  public Map<String, String> testUsersAndRoles() {
+    return Map.ofEntries(
+        entry(TEST_USER_USERNAME, roleUser),
+        entry(TEST_ADMIN_USERNAME, roleAdmin),
+        entry(TEST_NOT_PERMISSIONED_USER_USERNAME, "not-opendevstack-user"));
+  }
+
+  @Bean
+  @Primary
+  public IODSAuthnzAdapter iodsAuthnzAdapter() {
+    return mock(IODSAuthnzAdapter.class);
+  }
+
+  @Bean
+  @Primary
+  public EhCacheManagerFactoryBean getEhCacheFactory() {
+    EhCacheManagerFactoryBean factoryBean = new EhCacheManagerFactoryBean();
+    factoryBean.setConfigLocation(new ClassPathResource("crowd-ehcache.xml"));
+    factoryBean.setShared(false);
+    factoryBean.setAcceptExisting(true);
+    return factoryBean;
+  }
+}

--- a/src/test/java/org/opendevstack/provision/config/BasicAuthSecurityTestConfig.java
+++ b/src/test/java/org/opendevstack/provision/config/BasicAuthSecurityTestConfig.java
@@ -33,7 +33,7 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationEn
 @Configuration
 @Profile("utest")
 @ConditionalOnProperty(name = "provision.auth.basic-auth.enabled", havingValue = "utest")
-public class BasicAuthSecurityTestConfig extends AuthSecurityTestConfig {
+public class BasicAuthSecurityTestConfig {
 
   @Bean
   public BasicAuthenticationEntryPoint basicAuthenticationEntryPoint() {

--- a/src/test/java/org/opendevstack/provision/config/BasicAuthSecurityTestConfig.java
+++ b/src/test/java/org/opendevstack/provision/config/BasicAuthSecurityTestConfig.java
@@ -11,76 +11,41 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.opendevstack.provision.authentication.basic;
+package org.opendevstack.provision.config;
 
-import java.util.HashMap;
+import static org.opendevstack.provision.config.AuthSecurityTestConfig.TEST_VALID_CREDENTIAL;
+
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
 
-/**
- * Configuration of BasicAuth for testing purposes.
- *
- * <p>Never move it to src/main/java folder!
- */
 @Configuration
+@Profile("utest")
 @ConditionalOnProperty(name = "provision.auth.basic-auth.enabled", havingValue = "utest")
-public class BasicAuthSecurityTestConfig {
-
-  public static final String TEST_USER_USERNAME = "user";
-  public static final String TEST_USER_EMAIL = "user@example.com";
-  public static final String TEST_ADMIN_USERNAME = "admin";
-  public static final String TEST_ADMIN_EMAIL = "admin@example.com";
-  public static final String TEST_NOT_PERMISSIONED_USER_USERNAME = "not-permissioned-user";
-  public static final String TEST_NOT_PERMISSIONED_USER_EMAIL = "not-permissioned-user@example.com";
-  public static final String TEST_REALM = "test-realm";
-  public static final String TEST_VALID_CREDENTIAL = "validsecret";
-
-  @Value("${idmanager.group.opendevstack-users}")
-  private String roleUser;
-
-  @Value("${idmanager.group.opendevstack-administrators}")
-  private String roleAdmin;
+public class BasicAuthSecurityTestConfig extends AuthSecurityTestConfig {
 
   @Bean
   public BasicAuthenticationEntryPoint basicAuthenticationEntryPoint() {
     BasicAuthenticationEntryPoint entryPoint = new BasicAuthenticationEntryPoint();
-    entryPoint.setRealmName(TEST_REALM);
+    entryPoint.setRealmName("test-realm");
     return entryPoint;
   }
 
   @Bean
   public AuthenticationProvider authenticationProvider(
       @Qualifier("testUsersAndRoles") @Autowired Map<String, String> testUsersAndRoles) {
-    TestingAuthenticationProvider provider = new TestingAuthenticationProvider(testUsersAndRoles);
-    return provider;
-  }
-
-  @Bean
-  public PasswordEncoder passwordEncoder() {
-    return new BCryptPasswordEncoder();
-  }
-
-  @Bean(name = "testUsersAndRoles")
-  public Map<String, String> testUsersAndRoles() {
-    Map<String, String> users = new HashMap<>();
-    users.put(TEST_USER_USERNAME, roleUser);
-    users.put(TEST_ADMIN_USERNAME, roleAdmin);
-    users.put(TEST_NOT_PERMISSIONED_USER_USERNAME, "not-opendevstack-user");
-    return users;
+    return new TestingAuthenticationProvider(testUsersAndRoles);
   }
 
   private class TestingAuthenticationProvider
@@ -107,18 +72,10 @@ public class BasicAuthSecurityTestConfig {
           return null;
         }
 
-        UsernamePasswordAuthenticationToken authenticationToken =
-            new UsernamePasswordAuthenticationToken(
-                authentication.getPrincipal(),
-                authentication.getCredentials(),
-                List.of(
-                    new GrantedAuthority() {
-                      @Override
-                      public String getAuthority() {
-                        return users.get(username);
-                      }
-                    }));
-        return authenticationToken;
+        return new UsernamePasswordAuthenticationToken(
+            authentication.getPrincipal(),
+            authentication.getCredentials(),
+            List.of((GrantedAuthority) () -> users.get(username)));
       }
     }
 

--- a/src/test/java/org/opendevstack/provision/config/CrowdAuthSecurityTestConfig.java
+++ b/src/test/java/org/opendevstack/provision/config/CrowdAuthSecurityTestConfig.java
@@ -11,66 +11,34 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.opendevstack.provision.authentication.crowd;
+package org.opendevstack.provision.config;
+
+import static org.opendevstack.provision.config.AuthSecurityTestConfig.TEST_VALID_CREDENTIAL;
 
 import com.atlassian.crowd.integration.springsecurity.user.CrowdUserDetails;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
-/**
- * Configuration of BasicAuth for testing purposes.
- *
- * <p>Never move it to src/main/java folder!
- */
 @Configuration
+@Profile("utestcrowd")
 @ConditionalOnProperty(name = "provision.auth.provider", havingValue = "utestcrowd")
-public class CrowdAuthSecurityTestConfig {
-
-  public static final String TEST_USER_USERNAME = "user";
-  public static final String TEST_ADMIN_USERNAME = "admin";
-  public static final String TEST_NOT_PERMISSIONED_USER_USERNAME = "not-permissioned-user";
-  public static final String TEST_REALM = "test-realm";
-  public static final String TEST_VALID_CREDENTIAL = "validsecret";
-
-  @Value("${idmanager.group.opendevstack-users}")
-  private String roleUser;
-
-  @Value("${idmanager.group.opendevstack-administrators}")
-  private String roleAdmin;
+public class CrowdAuthSecurityTestConfig extends AuthSecurityTestConfig {
 
   @Bean
   public AuthenticationProvider authenticationProvider(
       @Qualifier("testUsersAndRoles") @Autowired Map<String, String> testUsersAndRoles) {
-    TestingAuthenticationProvider provider = new TestingAuthenticationProvider(testUsersAndRoles);
-    return provider;
-  }
-
-  @Bean
-  public PasswordEncoder passwordEncoder() {
-    return new BCryptPasswordEncoder();
-  }
-
-  @Bean(name = "testUsersAndRoles")
-  public Map<String, String> testUsersAndRoles() {
-    Map<String, String> users = new HashMap<>();
-    users.put(TEST_USER_USERNAME, roleUser);
-    users.put(TEST_ADMIN_USERNAME, roleAdmin);
-    users.put(TEST_NOT_PERMISSIONED_USER_USERNAME, "not-opendevstack-user");
-    return users;
+    return new TestingAuthenticationProvider(testUsersAndRoles);
   }
 
   private class TestingAuthenticationProvider
@@ -98,18 +66,10 @@ public class CrowdAuthSecurityTestConfig {
           return null;
         }
 
-        UsernamePasswordAuthenticationToken authenticationToken =
-            new UsernamePasswordAuthenticationToken(
-                authentication.getPrincipal(),
-                authentication.getCredentials(),
-                List.of(
-                    new GrantedAuthority() {
-                      @Override
-                      public String getAuthority() {
-                        return users.get(username);
-                      }
-                    }));
-        return authenticationToken;
+        return new UsernamePasswordAuthenticationToken(
+            authentication.getPrincipal(),
+            authentication.getCredentials(),
+            List.of((GrantedAuthority) () -> users.get(username)));
       }
     }
 

--- a/src/test/java/org/opendevstack/provision/config/CrowdAuthSecurityTestConfig.java
+++ b/src/test/java/org/opendevstack/provision/config/CrowdAuthSecurityTestConfig.java
@@ -33,7 +33,7 @@ import org.springframework.security.core.GrantedAuthority;
 @Configuration
 @Profile("utestcrowd")
 @ConditionalOnProperty(name = "provision.auth.provider", havingValue = "utestcrowd")
-public class CrowdAuthSecurityTestConfig extends AuthSecurityTestConfig {
+public class CrowdAuthSecurityTestConfig {
 
   @Bean
   public AuthenticationProvider authenticationProvider(

--- a/src/test/java/org/opendevstack/provision/config/OpenshiftServiceConfigTest.java
+++ b/src/test/java/org/opendevstack/provision/config/OpenshiftServiceConfigTest.java
@@ -13,7 +13,7 @@
  */
 package org.opendevstack.provision.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
 import org.opendevstack.provision.services.openshift.OpenshiftClient;

--- a/src/test/java/org/opendevstack/provision/controller/ApplicationInfoAPIControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/ApplicationInfoAPIControllerTest.java
@@ -14,7 +14,7 @@
 package org.opendevstack.provision.controller;
 
 import static org.mockito.Mockito.when;
-import static org.opendevstack.provision.authentication.basic.BasicAuthSecurityTestConfig.*;
+import static org.opendevstack.provision.config.AuthSecurityTestConfig.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 
 import java.util.HashMap;
@@ -31,12 +31,11 @@ import org.opendevstack.provision.authentication.UserRolesHolder;
 import org.opendevstack.provision.model.OpenProjectData;
 import org.opendevstack.provision.services.StorageAdapter;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -44,17 +43,14 @@ import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
 @ActiveProfiles("utest")
 @DirtiesContext
 public class ApplicationInfoAPIControllerTest {
 
-  private MockMvc mockMvc;
-
-  @Autowired private WebApplicationContext webApplicationContext;
+  @Autowired private MockMvc mockMvc;
 
   @MockBean private StorageAdapter storageAdapter;
 
@@ -68,10 +64,6 @@ public class ApplicationInfoAPIControllerTest {
 
   @MockBean private ICollaborationAdapter confluenceAdapter;
 
-  @Qualifier("testUsersAndRoles")
-  @Autowired
-  private Map<String, String> testUsersAndRoles;
-
   @Value("${idmanager.group.opendevstack-users}")
   private String idmanagerUserGroup;
 
@@ -80,12 +72,6 @@ public class ApplicationInfoAPIControllerTest {
 
   @BeforeEach
   public void setup() {
-
-    mockMvc =
-        MockMvcBuilders.webAppContextSetup(webApplicationContext)
-            .apply(SecurityMockMvcConfigurers.springSecurity())
-            .build();
-
     when(mockAuthnzAdapter.getUserName()).thenReturn(TEST_ADMIN_USERNAME);
     when(mockAuthnzAdapter.getUserEmail()).thenReturn(TEST_ADMIN_EMAIL);
     when(mockAuthnzAdapter.getUserPassword()).thenReturn(TEST_VALID_CREDENTIAL);

--- a/src/test/java/org/opendevstack/provision/controller/DefaultControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/DefaultControllerTest.java
@@ -41,7 +41,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
@@ -61,8 +60,6 @@ public class DefaultControllerTest {
   @Autowired private IBugtrackerAdapter realJiraAdapter;
 
   @Autowired private ICollaborationAdapter realConfluenceAdapter;
-
-  @Autowired private WebApplicationContext context;
 
   @Autowired private MockMvc mockMvc;
 

--- a/src/test/java/org/opendevstack/provision/controller/DefaultControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/DefaultControllerTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.opendevstack.provision.adapter.IBugtrackerAdapter;
 import org.opendevstack.provision.adapter.ICollaborationAdapter;
@@ -33,6 +32,7 @@ import org.opendevstack.provision.authentication.crowd.CrowdAuthenticationManage
 import org.opendevstack.provision.model.AboutChangesData;
 import org.opendevstack.provision.services.StorageAdapter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -41,10 +41,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles({"crowd", "quickstarters"})
 public class DefaultControllerTest {
 
@@ -52,7 +52,7 @@ public class DefaultControllerTest {
 
   @MockBean private StorageAdapter storageAdapter;
 
-  @Mock private CrowdAuthenticationManager crowdAuthenticationManager;
+  @MockBean private CrowdAuthenticationManager crowdAuthenticationManager;
 
   @Autowired private DefaultController defaultController;
 
@@ -64,12 +64,10 @@ public class DefaultControllerTest {
 
   @Autowired private WebApplicationContext context;
 
-  private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
   @BeforeEach
   public void setUp() {
-    // mockMvc without spring security
-    mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
     // reset to default value
     defaultController.setSpafrontendEnabled(false);
   }

--- a/src/test/java/org/opendevstack/provision/controller/DefaultControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/DefaultControllerTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.opendevstack.provision.adapter.IBugtrackerAdapter;
 import org.opendevstack.provision.adapter.ICollaborationAdapter;
@@ -32,7 +33,6 @@ import org.opendevstack.provision.authentication.crowd.CrowdAuthenticationManage
 import org.opendevstack.provision.model.AboutChangesData;
 import org.opendevstack.provision.services.StorageAdapter;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -41,9 +41,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
-@AutoConfigureMockMvc
 @ActiveProfiles({"crowd", "quickstarters"})
 public class DefaultControllerTest {
 
@@ -51,7 +52,7 @@ public class DefaultControllerTest {
 
   @MockBean private StorageAdapter storageAdapter;
 
-  @MockBean private CrowdAuthenticationManager crowdAuthenticationManager;
+  @Mock private CrowdAuthenticationManager crowdAuthenticationManager;
 
   @Autowired private DefaultController defaultController;
 
@@ -61,10 +62,14 @@ public class DefaultControllerTest {
 
   @Autowired private ICollaborationAdapter realConfluenceAdapter;
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired private WebApplicationContext context;
+
+  private MockMvc mockMvc;
 
   @BeforeEach
   public void setUp() {
+    // mockMvc without spring security
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
     // reset to default value
     defaultController.setSpafrontendEnabled(false);
   }

--- a/src/test/java/org/opendevstack/provision/controller/DefaultControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/DefaultControllerTest.java
@@ -32,6 +32,7 @@ import org.opendevstack.provision.authentication.crowd.CrowdAuthenticationManage
 import org.opendevstack.provision.model.AboutChangesData;
 import org.opendevstack.provision.services.StorageAdapter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -40,11 +41,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
-@ActiveProfiles({"crowd", "utestcrowd", "quickstarters"})
+@AutoConfigureMockMvc
+@ActiveProfiles({"crowd", "quickstarters"})
 public class DefaultControllerTest {
 
   @MockBean private IJobExecutionAdapter jobExecutionAdapter;
@@ -55,24 +55,16 @@ public class DefaultControllerTest {
 
   @Autowired private DefaultController defaultController;
 
-  @Autowired private WebApplicationContext context;
-
   @Autowired private ISCMAdapter realBitbucketAdapter;
 
   @Autowired private IBugtrackerAdapter realJiraAdapter;
 
   @Autowired private ICollaborationAdapter realConfluenceAdapter;
 
-  private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
   @BeforeEach
   public void setUp() {
-
-    mockMvc =
-        MockMvcBuilders.webAppContextSetup(context)
-            // .apply(SecurityMockMvcConfigurers.springSecurity())
-            .build();
-
     // reset to default value
     defaultController.setSpafrontendEnabled(false);
   }

--- a/src/test/java/org/opendevstack/provision/controller/E2EProjectAPIControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/E2EProjectAPIControllerTest.java
@@ -615,7 +615,6 @@ public class E2EProjectAPIControllerTest {
       return;
     }
 
-    // get the project through its key
     MvcResult resultProjectGetResponse =
         mockMvc
             .perform(
@@ -781,7 +780,6 @@ public class E2EProjectAPIControllerTest {
 
     assertEquals((currentQuickstarterSize - 1), resultProject.getQuickstarters().size());
 
-    // retrieve the project through the get endpoint - to ensure we have the right data stored
     resultProjectGetResponse =
         mockMvc
             .perform(

--- a/src/test/java/org/opendevstack/provision/controller/E2EProjectAPIControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/E2EProjectAPIControllerTest.java
@@ -18,7 +18,8 @@ import static java.lang.String.format;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static org.opendevstack.provision.authentication.basic.BasicAuthSecurityTestConfig.*;
+import static org.opendevstack.provision.config.AuthSecurityTestConfig.TEST_ADMIN_USERNAME;
+import static org.opendevstack.provision.config.AuthSecurityTestConfig.TEST_VALID_CREDENTIAL;
 import static org.opendevstack.provision.util.RestClientCallArgumentMatcher.matchesClientCall;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
@@ -43,7 +44,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.verification.VerificationMode;
 import org.opendevstack.provision.adapter.IODSAuthnzAdapter;
-import org.opendevstack.provision.authentication.basic.BasicAuthSecurityTestConfig;
 import org.opendevstack.provision.model.ExecutionJob;
 import org.opendevstack.provision.model.OpenProjectData;
 import org.opendevstack.provision.model.bitbucket.BitbucketProject;
@@ -59,12 +59,16 @@ import org.opendevstack.provision.model.jira.LeanJiraProject;
 import org.opendevstack.provision.model.jira.PermissionScheme;
 import org.opendevstack.provision.model.jira.PermissionSchemeResponse;
 import org.opendevstack.provision.model.webhookproxy.CreateProjectResponse;
-import org.opendevstack.provision.services.*;
+import org.opendevstack.provision.services.BitbucketAdapter;
+import org.opendevstack.provision.services.ConfluenceAdapter;
+import org.opendevstack.provision.services.CrowdProjectIdentityMgmtAdapter;
+import org.opendevstack.provision.services.JiraAdapter;
+import org.opendevstack.provision.services.JiraAdapterTests;
+import org.opendevstack.provision.services.MailAdapter;
 import org.opendevstack.provision.services.jira.JiraRestApi;
 import org.opendevstack.provision.services.openshift.OpenshiftClient;
 import org.opendevstack.provision.storage.LocalStorage;
 import org.opendevstack.provision.util.CreateProjectResponseUtil;
-import org.opendevstack.provision.util.RestClientCallArgumentMatcher;
 import org.opendevstack.provision.util.TestDataFileReader;
 import org.opendevstack.provision.util.exception.HttpException;
 import org.opendevstack.provision.util.rest.RestClient;
@@ -73,40 +77,35 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 
 /** End to end testcase with real result data - only mock is the RestClient - to feed the json */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
 @ActiveProfiles({"utest", "quickstarters"})
 @DirtiesContext
 public class E2EProjectAPIControllerTest {
 
-  private static Logger e2eLogger = LoggerFactory.getLogger(E2EProjectAPIControllerTest.class);
+  private static final Logger e2eLogger =
+      LoggerFactory.getLogger(E2EProjectAPIControllerTest.class);
 
   public static final String BITBUCKET_PARAM_FILTER = "filter";
   public static final String BITBUCKET_PARAM_PERMISSION = "permission";
 
-  public static final String TEST_ADMIN_USERNAME = BasicAuthSecurityTestConfig.TEST_ADMIN_USERNAME;
-  public static final String TEST_VALID_CREDENTIAL =
-      BasicAuthSecurityTestConfig.TEST_VALID_CREDENTIAL;
-
   private RestClientMockHelper mockHelper;
 
-  private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
   @MockBean private IODSAuthnzAdapter mockAuthnzAdapter;
 
@@ -115,8 +114,6 @@ public class E2EProjectAPIControllerTest {
   @MockBean private OpenshiftClient openshiftClient;
 
   @MockBean private CrowdProjectIdentityMgmtAdapter crowdProjectIdentityMgmtAdapter;
-
-  @Autowired private WebApplicationContext context;
 
   @Autowired private JiraAdapter realJiraAdapter;
 
@@ -130,8 +127,6 @@ public class E2EProjectAPIControllerTest {
 
   @Autowired private MailAdapter realMailAdapter;
 
-  @Autowired private TestRestTemplate template;
-
   @Value("${idmanager.group.opendevstack-users}")
   private String userGroup;
 
@@ -141,15 +136,13 @@ public class E2EProjectAPIControllerTest {
   @Value("${openshift.apps.basedomain}")
   protected String projectOpenshiftBaseDomain;
 
-  private static TestDataFileReader fileReader =
+  private static final TestDataFileReader fileReader =
       new TestDataFileReader(TestDataFileReader.TEST_DATA_FILE_DIR);
 
-  private static File testProjectDataDir =
+  private static final File testProjectDataDir =
       new File(TestDataFileReader.TEST_DATA_FILE_DIR, "results");
 
-  private static File buildDir = new File("./build");
-
-  private String VALID_CREDENTIAL = BasicAuthSecurityTestConfig.TEST_VALID_CREDENTIAL;
+  private static final File buildDir = new File("./build");
 
   @BeforeEach
   public void setUp() {
@@ -158,11 +151,6 @@ public class E2EProjectAPIControllerTest {
         realLocalStorageAdapter, E2EProjectAPIControllerTest.createTempDir(buildDir));
 
     apiController.setDirectStorage(realLocalStorageAdapter);
-
-    mockMvc =
-        MockMvcBuilders.webAppContextSetup(context)
-            .apply(SecurityMockMvcConfigurers.springSecurity())
-            .build();
 
     mockHelper = new RestClientMockHelper(restClient);
 
@@ -173,7 +161,6 @@ public class E2EProjectAPIControllerTest {
     apiController.setCleanupAllowed(true);
 
     when(mockAuthnzAdapter.getUserName()).thenReturn(TEST_ADMIN_USERNAME);
-    when(mockAuthnzAdapter.getUserEmail()).thenReturn(TEST_ADMIN_EMAIL);
     when(mockAuthnzAdapter.getUserPassword()).thenReturn(TEST_VALID_CREDENTIAL);
 
     when(openshiftClient.projects()).thenReturn(Set.of("default", "ods"));
@@ -322,15 +309,13 @@ public class E2EProjectAPIControllerTest {
 
     // get confluence blueprints
     List<Blueprint> blList =
-        readTestDataTypeRef(
-            "confluence-get-blueprints-response", new TypeReference<List<Blueprint>>() {});
+        readTestDataTypeRef("confluence-get-blueprints-response", new TypeReference<>() {});
 
     mockHelper
         .mockExecute(
             matchesClientCall().url(containsString("dialog/web-items")).method(HttpMethod.GET))
         .thenReturn(blList);
 
-    String confluenceSpaceTemplate = fileReader.readFileContent("confluence-get-space-template");
     try {
       mockHelper
           .mockExecuteSuppressErrorLogging(
@@ -401,8 +386,7 @@ public class E2EProjectAPIControllerTest {
 
     // get jira servers for confluence space
     List<JiraServer> jiraservers =
-        readTestDataTypeRef(
-            "confluence-get-jira-servers-response", new TypeReference<List<JiraServer>>() {});
+        readTestDataTypeRef("confluence-get-jira-servers-response", new TypeReference<>() {});
 
     mockHelper
         .mockExecute(
@@ -560,7 +544,7 @@ public class E2EProjectAPIControllerTest {
                 post("/api/v2/project")
                     .content(ProjectApiControllerTest.asJsonString(data))
                     .contentType(MediaType.APPLICATION_JSON)
-                    .with(httpBasic(TEST_ADMIN_USERNAME, VALID_CREDENTIAL))
+                    .with(httpBasic(TEST_ADMIN_USERNAME, TEST_VALID_CREDENTIAL))
                     .accept(MediaType.APPLICATION_JSON))
             .andDo(MockMvcResultHandlers.print())
             .andReturn();
@@ -631,13 +615,13 @@ public class E2EProjectAPIControllerTest {
       return;
     }
 
-    // get the project thru its key
+    // get the project through its key
     MvcResult resultProjectGetResponse =
         mockMvc
             .perform(
                 get("/api/v2/project/" + data.projectKey)
                     .accept(MediaType.APPLICATION_JSON)
-                    .with(httpBasic(TEST_ADMIN_USERNAME, VALID_CREDENTIAL)))
+                    .with(httpBasic(TEST_ADMIN_USERNAME, TEST_VALID_CREDENTIAL)))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andDo(MockMvcResultHandlers.print())
             .andReturn();
@@ -713,7 +697,7 @@ public class E2EProjectAPIControllerTest {
         .perform(
             get("/api/v2/project/" + toClean.projectKey)
                 .contentType(MediaType.APPLICATION_JSON)
-                .with(httpBasic(TEST_ADMIN_USERNAME, VALID_CREDENTIAL))
+                .with(httpBasic(TEST_ADMIN_USERNAME, TEST_VALID_CREDENTIAL))
                 .accept(MediaType.APPLICATION_JSON))
         .andDo(MockMvcResultHandlers.print())
         .andExpect(MockMvcResultMatchers.status().isOk());
@@ -724,7 +708,7 @@ public class E2EProjectAPIControllerTest {
         .perform(
             delete("/api/v2/project/" + toClean.projectKey)
                 .contentType(MediaType.APPLICATION_JSON)
-                .with(httpBasic(TEST_ADMIN_USERNAME, VALID_CREDENTIAL))
+                .with(httpBasic(TEST_ADMIN_USERNAME, TEST_VALID_CREDENTIAL))
                 .accept(MediaType.APPLICATION_JSON))
         .andDo(MockMvcResultHandlers.print())
         .andExpect(MockMvcResultMatchers.status().isOk());
@@ -734,7 +718,7 @@ public class E2EProjectAPIControllerTest {
         .perform(
             get("/api/v2/project/" + toClean.projectKey)
                 .contentType(MediaType.APPLICATION_JSON)
-                .with(httpBasic(TEST_ADMIN_USERNAME, VALID_CREDENTIAL))
+                .with(httpBasic(TEST_ADMIN_USERNAME, TEST_VALID_CREDENTIAL))
                 .accept(MediaType.APPLICATION_JSON))
         .andDo(MockMvcResultHandlers.print())
         .andExpect(MockMvcResultMatchers.status().isNotFound());
@@ -781,7 +765,7 @@ public class E2EProjectAPIControllerTest {
                 delete("/api/v2/project/")
                     .content(ProjectApiControllerTest.asJsonString(toClean))
                     .contentType(MediaType.APPLICATION_JSON)
-                    .with(httpBasic(TEST_ADMIN_USERNAME, VALID_CREDENTIAL))
+                    .with(httpBasic(TEST_ADMIN_USERNAME, TEST_VALID_CREDENTIAL))
                     .accept(MediaType.APPLICATION_JSON))
             .andDo(MockMvcResultHandlers.print())
             .andExpect(MockMvcResultMatchers.status().isOk())
@@ -795,15 +779,15 @@ public class E2EProjectAPIControllerTest {
             .readValue(
                 resultProjectGetResponse.getResponse().getContentAsString(), OpenProjectData.class);
 
-    assertTrue(resultProject.getQuickstarters().size() == (currentQuickstarterSize - 1));
+    assertEquals((currentQuickstarterSize - 1), resultProject.getQuickstarters().size());
 
-    // retrieve the project thru the get endpoint - to ensure we have the right data stored
+    // retrieve the project through the get endpoint - to ensure we have the right data stored
     resultProjectGetResponse =
         mockMvc
             .perform(
                 get("/api/v2/project/" + toClean.projectKey)
                     .contentType(MediaType.APPLICATION_JSON)
-                    .with(httpBasic(TEST_ADMIN_USERNAME, VALID_CREDENTIAL))
+                    .with(httpBasic(TEST_ADMIN_USERNAME, TEST_VALID_CREDENTIAL))
                     .accept(MediaType.APPLICATION_JSON))
             .andDo(MockMvcResultHandlers.print())
             .andExpect(MockMvcResultMatchers.status().isOk())
@@ -815,7 +799,7 @@ public class E2EProjectAPIControllerTest {
                 resultProjectGetResponse.getResponse().getContentAsString(), OpenProjectData.class);
 
     assertEquals(toClean.projectKey, resultProject.projectKey);
-    assertTrue(resultProject.getQuickstarters().size() == (currentQuickstarterSize - 1));
+    assertEquals((currentQuickstarterSize - 1), resultProject.getQuickstarters().size());
     assertTrue(resultProject.getQuickstarters().isEmpty());
   }
 
@@ -919,7 +903,7 @@ public class E2EProjectAPIControllerTest {
                 put("/api/v2/project")
                     .content(ProjectApiControllerTest.asJsonString(dataUpdate))
                     .contentType(MediaType.APPLICATION_JSON)
-                    .with(httpBasic(TEST_ADMIN_USERNAME, VALID_CREDENTIAL))
+                    .with(httpBasic(TEST_ADMIN_USERNAME, TEST_VALID_CREDENTIAL))
                     .accept(MediaType.APPLICATION_JSON))
             .andDo(MockMvcResultHandlers.print())
             .andReturn();
@@ -984,11 +968,6 @@ public class E2EProjectAPIControllerTest {
     return resultProject;
   }
 
-  public void oldVerify(VerificationMode times, RestClientCallArgumentMatcher wantedArgument)
-      throws IOException {
-    mockHelper.verifyExecute(wantedArgument, times);
-  }
-
   /** Test legacy upgrade e2e */
   @Test
   public void testLegacyProjectUpgradeOnGet() throws Exception {
@@ -1003,7 +982,7 @@ public class E2EProjectAPIControllerTest {
             .perform(
                 get("/api/v2/project/LEGPROJ")
                     .accept(MediaType.APPLICATION_JSON)
-                    .with(httpBasic(TEST_ADMIN_USERNAME, VALID_CREDENTIAL)))
+                    .with(httpBasic(TEST_ADMIN_USERNAME, TEST_VALID_CREDENTIAL)))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andDo(MockMvcResultHandlers.print())
             .andReturn();
@@ -1032,7 +1011,7 @@ public class E2EProjectAPIControllerTest {
     mockMvc
         .perform(
             get("/api/v2/project/LEGPROJ")
-                .with(httpBasic(TEST_ADMIN_USERNAME, VALID_CREDENTIAL))
+                .with(httpBasic(TEST_ADMIN_USERNAME, TEST_VALID_CREDENTIAL))
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(

--- a/src/test/java/org/opendevstack/provision/controller/ProjectApiControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/ProjectApiControllerTest.java
@@ -18,12 +18,20 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.Mockito.*;
+import static org.opendevstack.provision.config.AuthSecurityTestConfig.TEST_ADMIN_USERNAME;
+import static org.opendevstack.provision.config.AuthSecurityTestConfig.TEST_VALID_CREDENTIAL;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -32,13 +40,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.verification.VerificationMode;
-import org.opendevstack.provision.adapter.*;
+import org.opendevstack.provision.adapter.IBugtrackerAdapter;
+import org.opendevstack.provision.adapter.ICollaborationAdapter;
+import org.opendevstack.provision.adapter.IJobExecutionAdapter;
+import org.opendevstack.provision.adapter.ISCMAdapter;
 import org.opendevstack.provision.adapter.ISCMAdapter.URL_TYPE;
+import org.opendevstack.provision.adapter.IServiceAdapter;
 import org.opendevstack.provision.adapter.exception.AdapterException;
 import org.opendevstack.provision.adapter.exception.CreateProjectPreconditionException;
 import org.opendevstack.provision.authentication.TestAuthentication;
-import org.opendevstack.provision.authentication.crowd.CrowdAuthSecurityTestConfig;
-import org.opendevstack.provision.authentication.crowd.CrowdAuthenticationManager;
 import org.opendevstack.provision.model.OpenProjectData;
 import org.opendevstack.provision.model.ProjectData;
 import org.opendevstack.provision.services.CrowdProjectIdentityMgmtAdapter;
@@ -46,10 +56,9 @@ import org.opendevstack.provision.services.MailAdapter;
 import org.opendevstack.provision.services.StorageAdapter;
 import org.opendevstack.provision.services.openshift.OpenshiftClient;
 import org.opendevstack.provision.storage.IStorage;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
@@ -62,15 +71,14 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
 @ActiveProfiles({"crowd", "utestcrowd", "quickstarters"})
 @DirtiesContext
 public class ProjectApiControllerTest {
 
-  private static Logger logger = LoggerFactory.getLogger(ProjectApiControllerTest.class);
+  @Autowired private MockMvc mockMvc;
 
   @MockBean private OpenshiftClient openshiftClient;
 
@@ -90,39 +98,23 @@ public class ProjectApiControllerTest {
 
   @MockBean private CrowdProjectIdentityMgmtAdapter idm;
 
-  @MockBean private CrowdAuthenticationManager crowdAuthenticationManager;
-
   @Autowired private ProjectApiController apiController;
 
   @Autowired private List<String> projectTemplateKeyNames;
 
-  @Autowired private WebApplicationContext context;
-
   @Value("${idmanager.group.opendevstack-administrators}")
   private String roleAdmin;
-
-  private MockMvc mockMvc;
 
   private OpenProjectData data;
 
   @BeforeEach
   public void setUp() {
-
-    mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
-
-    GrantedAuthority auth =
-        new GrantedAuthority() {
-          @Override
-          public String getAuthority() {
-            return roleAdmin;
-          }
-        };
-
+    GrantedAuthority auth = () -> roleAdmin;
     SecurityContextHolder.getContext()
         .setAuthentication(
             new TestAuthentication(
-                CrowdAuthSecurityTestConfig.TEST_ADMIN_USERNAME,
-                CrowdAuthSecurityTestConfig.TEST_VALID_CREDENTIAL,
+                TEST_ADMIN_USERNAME,
+                TEST_VALID_CREDENTIAL,
                 List.of(auth).toArray(GrantedAuthority[]::new)));
 
     initOpenProjectData();
@@ -199,8 +191,7 @@ public class ProjectApiControllerTest {
   }
 
   @Test
-  public void addProjectWithOC() throws Exception {
-
+  public void addProjectWithOC() {
     List.of(true, false)
         .forEach(
             confluenceAdapterEnabled -> {
@@ -211,8 +202,7 @@ public class ProjectApiControllerTest {
                 data.quickstarters = null;
 
                 OpenProjectData bugTrackProject = copyFromProject(data);
-                String bugtrackerUrl = "bugtracker";
-                bugTrackProject.bugtrackerUrl = bugtrackerUrl;
+                bugTrackProject.bugtrackerUrl = "bugtracker";
                 String collaborationSpaceURL = "collspace";
                 bugTrackProject.collaborationSpaceUrl = collaborationSpaceURL;
 
@@ -249,7 +239,7 @@ public class ProjectApiControllerTest {
                     .andExpect(MockMvcResultMatchers.status().isOk())
                     .andDo(MockMvcResultHandlers.print());
 
-                verifyAddProjectAdapterCalls(times(1), times(confluenceAdapterEnabled ? 1 : 0));
+                verifyAddProjectAdapterCalls(times(1));
               } catch (Exception e) {
                 throw new RuntimeException(e);
               }
@@ -303,10 +293,6 @@ public class ProjectApiControllerTest {
 
   public void verifyCheckPreconditionsCalls(VerificationMode platform, VerificationMode bugtracker)
       throws CreateProjectPreconditionException, IOException {
-
-    //    VerificationMode platform = platformProject ? times(1) : times(0);
-    //    VerificationMode bugtracker = bugtrackerProject ? times(1) : times(0);
-
     Mockito.verify(bitbucketAdapter, platform).checkCreateProjectPreconditions(isNotNull());
     // jira components
     Mockito.verify(jiraAdapter, bugtracker).checkCreateProjectPreconditions(isNotNull());
@@ -314,16 +300,9 @@ public class ProjectApiControllerTest {
 
     Mockito.verify(jenkinsPipelineAdapter, never()).createPlatformProjects(isNotNull());
     Mockito.verify(bitbucketAdapter, never()).createSCMProjectForODSProject(isNotNull());
-
-    //    reset(bitbucketAdapter, jiraAdapter, confluenceAdapter);
   }
 
   public void verifyAddProjectAdapterCalls(VerificationMode times)
-      throws IOException, CreateProjectPreconditionException {
-    verifyAddProjectAdapterCalls(times, times);
-  }
-
-  public void verifyAddProjectAdapterCalls(VerificationMode times, VerificationMode confluenceTimes)
       throws IOException, CreateProjectPreconditionException {
     Mockito.verify(jenkinsPipelineAdapter, times).createPlatformProjects(isNotNull());
     // check preconditions should be always called
@@ -908,7 +887,7 @@ public class ProjectApiControllerTest {
   }
 
   @Test
-  public void updateProjectWithValidAndInvalidComponentId() throws Exception {
+  public void updateProjectWithValidAndInvalidComponentId() {
 
     // allow upgrade
     apiController.setOcUpgradeAllowed(true);
@@ -953,7 +932,7 @@ public class ProjectApiControllerTest {
 
     String tooShort = "ad";
     String tooLong = "1234567890123456789012345678901234567890addd";
-    Arrays.asList(".-adfasfdasdfasdfsad", tooShort, tooLong, "", null).stream()
+    Arrays.asList(".-adfasfdasdfasdfsad", tooShort, tooLong, "", null)
         .forEach(s -> request.accept(s, false));
   }
 
@@ -1011,8 +990,7 @@ public class ProjectApiControllerTest {
   public static String asJsonString(final Object obj) {
     try {
       final ObjectMapper mapper = new ObjectMapper();
-      final String jsonContent = mapper.writeValueAsString(obj);
-      return jsonContent;
+      return mapper.writeValueAsString(obj);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -1065,8 +1043,7 @@ public class ProjectApiControllerTest {
 
     // case parameter is null
     try {
-      ProjectApiController.validateQuickstarters(
-          null, new ArrayList<Consumer<Map<String, String>>>());
+      ProjectApiController.validateQuickstarters(null, new ArrayList<>());
     } catch (IllegalArgumentException e) {
       // expected!
       assertTrue(e.getMessage().contains("null"));
@@ -1074,18 +1051,14 @@ public class ProjectApiControllerTest {
 
     // case validators list is empty
     try {
-      ProjectApiController.validateQuickstarters(
-          data, new ArrayList<Consumer<Map<String, String>>>());
+      ProjectApiController.validateQuickstarters(data, new ArrayList<>());
     } catch (IllegalArgumentException e) {
       // expected!
       assertTrue(e.getMessage().contains("validators"));
     }
 
     // case data is not null and validators is not empty
-    Consumer<Map<String, String>> acceptAllValidator =
-        stringStringMap -> {
-          return;
-        };
-    ProjectApiController.validateQuickstarters(data, Arrays.asList(acceptAllValidator));
+    Consumer<Map<String, String>> acceptAllValidator = stringStringMap -> {};
+    ProjectApiController.validateQuickstarters(data, Collections.singletonList(acceptAllValidator));
   }
 }

--- a/src/test/java/org/opendevstack/provision/controller/ProjectApiControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/ProjectApiControllerTest.java
@@ -71,7 +71,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc(addFilters = false)
@@ -100,8 +99,6 @@ public class ProjectApiControllerTest {
   @Autowired private ProjectApiController apiController;
 
   @Autowired private List<String> projectTemplateKeyNames;
-
-  @Autowired private WebApplicationContext context;
 
   @Autowired private MockMvc mockMvc;
 

--- a/src/test/java/org/opendevstack/provision/controller/ProjectApiControllerTest.java
+++ b/src/test/java/org/opendevstack/provision/controller/ProjectApiControllerTest.java
@@ -58,7 +58,6 @@ import org.opendevstack.provision.services.openshift.OpenshiftClient;
 import org.opendevstack.provision.storage.IStorage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
@@ -71,14 +70,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc
 @ActiveProfiles({"crowd", "utestcrowd", "quickstarters"})
 @DirtiesContext
 public class ProjectApiControllerTest {
-
-  @Autowired private MockMvc mockMvc;
 
   @MockBean private OpenshiftClient openshiftClient;
 
@@ -102,6 +100,10 @@ public class ProjectApiControllerTest {
 
   @Autowired private List<String> projectTemplateKeyNames;
 
+  @Autowired private WebApplicationContext context;
+
+  private MockMvc mockMvc;
+
   @Value("${idmanager.group.opendevstack-administrators}")
   private String roleAdmin;
 
@@ -109,6 +111,9 @@ public class ProjectApiControllerTest {
 
   @BeforeEach
   public void setUp() {
+    // mockMvc without spring security
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+
     GrantedAuthority auth = () -> roleAdmin;
     SecurityContextHolder.getContext()
         .setAuthentication(

--- a/src/test/java/org/opendevstack/provision/services/AbstractBaseServiceAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/AbstractBaseServiceAdapterTest.java
@@ -2,7 +2,6 @@ package org.opendevstack.provision.services;
 
 import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
-import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.verification.VerificationMode;
 import org.opendevstack.provision.util.RestClientCallArgumentMatcher;
@@ -22,7 +21,6 @@ public abstract class AbstractBaseServiceAdapterTest {
 
   @BeforeEach
   public void beforeTest() {
-    MockitoAnnotations.initMocks(this);
     mockHelper = new RestClientMockHelper(restClient);
   }
 

--- a/src/test/java/org/opendevstack/provision/services/BitbucketAdapterManualTest.java
+++ b/src/test/java/org/opendevstack/provision/services/BitbucketAdapterManualTest.java
@@ -13,17 +13,15 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles({"oauth2", "oauth2private"})
 @Disabled("Only exists for manual execution")
-public class JiraAdapterMT {
+public class BitbucketAdapterManualTest {
 
-  @Autowired private JiraAdapter jiraAdapter;
+  @Autowired private BitbucketAdapter bitbucketAdapter;
 
   @Autowired private LocalStorage localStorage;
 
   @Test
   public void deletesProjects() {
-    // take care that you use an existing jira project that can be deleted. Since this is an
-    // real integration test, it will really delete the project.
-    OpenProjectData project = localStorage.getProject("TEST34");
-    jiraAdapter.cleanup(LIFECYCLE_STAGE.INITIAL_CREATION, project);
+    OpenProjectData project = localStorage.getProject("TEST6");
+    bitbucketAdapter.cleanup(LIFECYCLE_STAGE.INITIAL_CREATION, project);
   }
 }

--- a/src/test/java/org/opendevstack/provision/services/CleanupAtlassianProjectsMT.java
+++ b/src/test/java/org/opendevstack/provision/services/CleanupAtlassianProjectsMT.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -30,7 +31,7 @@ public class CleanupAtlassianProjectsMT {
 
   private static final Logger LOG = LoggerFactory.getLogger(CleanupAtlassianProjectsMT.class);
 
-  @Autowired private RestClient restClient;
+  @MockBean private RestClient restClient;
 
   @Autowired private JiraAdapter jiraAdapter;
 
@@ -71,7 +72,7 @@ public class CleanupAtlassianProjectsMT {
   }
 
   @Test
-  public void cleanupConfluence() throws IOException {
+  public void cleanupConfluence() {
     deleteConfluenceSpaces("x1", "x2");
   }
 

--- a/src/test/java/org/opendevstack/provision/services/CleanupAtlassianProjectsManualTest.java
+++ b/src/test/java/org/opendevstack/provision/services/CleanupAtlassianProjectsManualTest.java
@@ -27,9 +27,10 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("testods")
 @Disabled("Only exists for manual execution")
-public class CleanupAtlassianProjectsMT {
+public class CleanupAtlassianProjectsManualTest {
 
-  private static final Logger LOG = LoggerFactory.getLogger(CleanupAtlassianProjectsMT.class);
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CleanupAtlassianProjectsManualTest.class);
 
   @MockBean private RestClient restClient;
 

--- a/src/test/java/org/opendevstack/provision/services/ConfluenceAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/ConfluenceAdapterTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 import static org.opendevstack.provision.util.RestClientCallArgumentMatcher.matchesClientCall;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +29,6 @@ import java.util.Map;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mockito;
 import org.opendevstack.provision.adapter.IODSAuthnzAdapter;
 import org.opendevstack.provision.adapter.IServiceAdapter;
@@ -43,13 +41,10 @@ import org.opendevstack.provision.model.confluence.Space;
 import org.opendevstack.provision.model.confluence.SpaceData;
 import org.opendevstack.provision.util.TestDataFileReader;
 import org.opendevstack.provision.util.exception.HttpException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.http.HttpMethod;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -59,24 +54,18 @@ import org.springframework.test.context.ActiveProfiles;
 @DirtiesContext
 public class ConfluenceAdapterTest extends AbstractBaseServiceAdapterTest {
 
-  private static final Logger logger = LoggerFactory.getLogger(ConfluenceAdapterTest.class);
-
   public static final String TEST_USER_NAME = "testUserName";
   public static final String TEST_USER_PASSWORD = "testUserPassword";
 
-  private ObjectMapper objectMapper;
-
-  private static TestDataFileReader fileReader =
+  private static final TestDataFileReader fileReader =
       new TestDataFileReader(TestDataFileReader.TEST_DATA_FILE_DIR);
+
+  @Autowired private ConfluenceAdapter confluenceAdapter;
 
   @MockBean private IODSAuthnzAdapter authnzAdapter;
 
-  @Autowired @InjectMocks ConfluenceAdapter confluenceAdapter;
-
   @Value("${confluence.blueprint.key}")
   private String confluenceBlueprintKey;
-
-  @Autowired ConfigurableEnvironment environment;
 
   @BeforeEach
   public void initTests() {
@@ -145,7 +134,7 @@ public class ConfluenceAdapterTest extends AbstractBaseServiceAdapterTest {
     project.projectUserGroup = "adminGroup";
     project.projectReadonlyGroup = "adminGroup";
 
-    List blList = new ArrayList<>();
+    var blList = new ArrayList<>();
     Blueprint bPrint = new Blueprint();
     bPrint.setBlueprintModuleCompleteKey(confluenceBlueprintKey);
     bPrint.setContentBlueprintId("1234");
@@ -269,7 +258,7 @@ public class ConfluenceAdapterTest extends AbstractBaseServiceAdapterTest {
       checkProjectKeyExists.apply(new ArrayList<>());
       fail();
     } catch (Exception e) {
-      assertTrue(IllegalArgumentException.class.isInstance(e));
+      assertTrue(e instanceof IllegalArgumentException);
     }
 
     // Case IOException throw from rest client!

--- a/src/test/java/org/opendevstack/provision/services/CrowdProjectIdentityMgmtAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/CrowdProjectIdentityMgmtAdapterTest.java
@@ -21,20 +21,22 @@ import static org.mockito.Mockito.when;
 import com.atlassian.crowd.integration.soap.SOAPGroup;
 import com.atlassian.crowd.integration.soap.SOAPPrincipal;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.opendevstack.provision.adapter.IODSAuthnzAdapter;
 import org.opendevstack.provision.adapter.exception.IdMgmtException;
-import org.opendevstack.provision.authentication.crowd.CrowdAuthenticationManager;
 import org.opendevstack.provision.model.OpenProjectData;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 
-@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@DirtiesContext
+@ActiveProfiles("crowd")
 public class CrowdProjectIdentityMgmtAdapterTest {
 
-  @Mock CrowdAuthenticationManager manager;
-
-  @InjectMocks CrowdProjectIdentityMgmtAdapter idMgr;
+  @Autowired private CrowdProjectIdentityMgmtAdapter idMgr;
+  @MockBean private IODSAuthnzAdapter manager;
 
   @Test
   public void testGroupExists() {

--- a/src/test/java/org/opendevstack/provision/services/CrowdProjectIdentityMgmtAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/CrowdProjectIdentityMgmtAdapterTest.java
@@ -21,22 +21,20 @@ import static org.mockito.Mockito.when;
 import com.atlassian.crowd.integration.soap.SOAPGroup;
 import com.atlassian.crowd.integration.soap.SOAPPrincipal;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opendevstack.provision.adapter.IODSAuthnzAdapter;
 import org.opendevstack.provision.adapter.exception.IdMgmtException;
 import org.opendevstack.provision.model.OpenProjectData;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@DirtiesContext
-@ActiveProfiles("crowd")
+@ExtendWith(MockitoExtension.class)
 public class CrowdProjectIdentityMgmtAdapterTest {
 
-  @Autowired private CrowdProjectIdentityMgmtAdapter idMgr;
-  @MockBean private IODSAuthnzAdapter manager;
+  @InjectMocks private CrowdProjectIdentityMgmtAdapter idMgr;
+
+  @Mock private IODSAuthnzAdapter manager;
 
   @Test
   public void testGroupExists() {

--- a/src/test/java/org/opendevstack/provision/services/JenkinsPipelineAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/JenkinsPipelineAdapterTest.java
@@ -14,20 +14,24 @@
 
 package org.opendevstack.provision.services;
 
-import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.opendevstack.provision.config.Quickstarter.adminjobQuickstarter;
 import static org.opendevstack.provision.config.Quickstarter.componentQuickstarter;
 import static org.opendevstack.provision.util.RestClientCallArgumentMatcher.matchesClientCall;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 import org.apache.commons.lang3.NotImplementedException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.opendevstack.provision.config.JenkinsPipelineProperties;
 import org.opendevstack.provision.model.ExecutionsData;
 import org.opendevstack.provision.model.OpenProjectData;
@@ -62,10 +66,7 @@ public class JenkinsPipelineAdapterTest extends AbstractBaseServiceAdapterTest {
 
   @BeforeEach
   public void setup() {
-    MockitoAnnotations.initMocks(this);
-
     jenkinsPipelineAdapter.jenkinsPipelineProperties = buildJenkinsPipelineProperties();
-
     jenkinsPipelineAdapter.groupPattern = "org.opendevstack.%s";
     jenkinsPipelineAdapter.adminWebhookProxyHost = "webhook-proxy-ods";
     jenkinsPipelineAdapter.projectWebhookProxyHostPattern = "webhook-proxy-%s-cd%s";
@@ -143,7 +144,7 @@ public class JenkinsPipelineAdapterTest extends AbstractBaseServiceAdapterTest {
     quickstart.add(testjob);
     project.quickstarters = quickstart;
 
-    mockJobsInServer(asList(job));
+    mockJobsInServer(Collections.singletonList(job));
 
     int expectedExecutionsSize = 1;
     ValueCaptor<Execution> bodyCaptor = new ValueCaptor<>();
@@ -198,12 +199,6 @@ public class JenkinsPipelineAdapterTest extends AbstractBaseServiceAdapterTest {
             Optional.empty(),
             odsGitRef);
 
-    String componentId = "be-project-name-with-numbers-123";
-
-    Map<String, String> testjob = new HashMap<>();
-    testjob.put(OpenProjectData.COMPONENT_ID_KEY, componentId);
-    testjob.put(OpenProjectData.COMPONENT_TYPE_KEY, job.getId());
-
     // Case: do not delete component job
     String expectedUrl =
         "https://"
@@ -215,9 +210,11 @@ public class JenkinsPipelineAdapterTest extends AbstractBaseServiceAdapterTest {
             + "&component=ods-corejob-"
             + job.getId();
 
+    String componentId = "be-project-name-with-numbers-123";
     String actualUrl =
         JenkinsPipelineAdapter.buildAdminJobExecutionUrl(
             job, componentId, job.getId(), webhookProxySecret, webhookHost, false);
+
     assertEquals(expectedUrl, actualUrl);
   }
 
@@ -238,10 +235,6 @@ public class JenkinsPipelineAdapterTest extends AbstractBaseServiceAdapterTest {
 
     String projectId = "be-acc-service-with-123-numbers";
 
-    Map<String, String> testjob = new HashMap<>();
-    testjob.put(OpenProjectData.COMPONENT_ID_KEY, projectId);
-    testjob.put(OpenProjectData.COMPONENT_TYPE_KEY, job.getId());
-
     // Case: delete component job
     String expectedUrl =
         "https://"
@@ -257,10 +250,6 @@ public class JenkinsPipelineAdapterTest extends AbstractBaseServiceAdapterTest {
         JenkinsPipelineAdapter.buildAdminJobExecutionUrl(
             job, projectId, job.getId(), webhookProxySecret, webhookHost, true);
     assertEquals(expectedUrl, actualUrl);
-  }
-
-  private void mockRestClientToReturnExecutionData(String output) throws java.io.IOException {
-    mockExecute(matchesClientCall().method(HttpMethod.POST)).thenReturn(output);
   }
 
   @Test

--- a/src/test/java/org/opendevstack/provision/services/JiraAdapterManualTest.java
+++ b/src/test/java/org/opendevstack/provision/services/JiraAdapterManualTest.java
@@ -13,15 +13,17 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles({"oauth2", "oauth2private"})
 @Disabled("Only exists for manual execution")
-public class BitbucketAdapterMT {
+public class JiraAdapterManualTest {
 
-  @Autowired private BitbucketAdapter bitbucketAdapter;
+  @Autowired private JiraAdapter jiraAdapter;
 
   @Autowired private LocalStorage localStorage;
 
   @Test
   public void deletesProjects() {
-    OpenProjectData project = localStorage.getProject("TEST6");
-    bitbucketAdapter.cleanup(LIFECYCLE_STAGE.INITIAL_CREATION, project);
+    // take care that you use an existing jira project that can be deleted. Since this is an
+    // real integration test, it will really delete the project.
+    OpenProjectData project = localStorage.getProject("TEST34");
+    jiraAdapter.cleanup(LIFECYCLE_STAGE.INITIAL_CREATION, project);
   }
 }

--- a/src/test/java/org/opendevstack/provision/services/MailAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/MailAdapterTest.java
@@ -27,16 +27,19 @@ import org.opendevstack.provision.authentication.crowd.CrowdAuthenticationManage
 import org.opendevstack.provision.model.OpenProjectData;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@DirtiesContext
 @ActiveProfiles("crowd")
 public class MailAdapterTest {
 
   @Autowired private MailAdapter mailAdapter;
 
-  @Mock private CrowdAuthenticationManager crowdAuthenticationManager;
+  @MockBean private CrowdAuthenticationManager crowdAuthenticationManager;
 
   @Mock private JavaMailSender mailSender;
 

--- a/src/test/java/org/opendevstack/provision/services/MailAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/MailAdapterTest.java
@@ -35,13 +35,14 @@ import org.springframework.test.context.ActiveProfiles;
 public class MailAdapterTest {
 
   @Autowired private MailAdapter mailAdapter;
-  @Autowired private CrowdAuthenticationManager manager;
 
-  @Mock JavaMailSender mailSender;
+  @Mock private CrowdAuthenticationManager crowdAuthenticationManager;
+
+  @Mock private JavaMailSender mailSender;
 
   @BeforeEach
   public void setUp() {
-    mailAdapter.manager = manager;
+    mailAdapter.manager = crowdAuthenticationManager;
   }
 
   @Test

--- a/src/test/java/org/opendevstack/provision/services/MailAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/MailAdapterTest.java
@@ -14,46 +14,40 @@
 
 package org.opendevstack.provision.services;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 
 import javax.mail.internet.MimeMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.opendevstack.provision.authentication.crowd.CrowdAuthenticationManager;
 import org.opendevstack.provision.model.OpenProjectData;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@DirtiesContext
 @ActiveProfiles("crowd")
 public class MailAdapterTest {
+
+  @Autowired private MailAdapter mailAdapter;
+  @Autowired private CrowdAuthenticationManager manager;
+
   @Mock JavaMailSender mailSender;
-
-  @InjectMocks @Autowired MailAdapter mailAdapter;
-
-  @Autowired CrowdAuthenticationManager manager;
 
   @BeforeEach
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
     mailAdapter.manager = manager;
   }
 
   @Test
   public void notifyUsersAboutProject() {
-    MailAdapter spyAdapter = Mockito.spy(mailAdapter);
+    MailAdapter spyAdapter = new MailAdapter(mailSender);
     Mockito.doNothing().when(mailSender).send(any(MimeMessage.class));
-    spyAdapter = new MailAdapter(mailSender);
 
     spyAdapter.notifyUsersAboutProject(new OpenProjectData());
   }
@@ -80,6 +74,6 @@ public class MailAdapterTest {
 
     String message = spyAdapter.build(new OpenProjectData());
     assertNotNull(message);
-    assertTrue(message.trim().length() > 0);
+    assertFalse(message.trim().isEmpty());
   }
 }

--- a/src/test/java/org/opendevstack/provision/services/MailAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/MailAdapterTest.java
@@ -14,19 +14,15 @@
 
 package org.opendevstack.provision.services;
 
-import static org.mockito.ArgumentMatchers.*;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opendevstack.provision.authentication.crowd.CrowdAuthenticationManager;
 import org.opendevstack.provision.model.OpenProjectData;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessagePreparator;
 
 @ExtendWith(MockitoExtension.class)
 public class MailAdapterTest {
@@ -47,15 +43,6 @@ public class MailAdapterTest {
   public void notifyUsersAboutProjectMailEnabled() {
     mailAdapter.isMailEnabled = true;
     mailAdapter.notifyUsersAboutProject(new OpenProjectData());
-
-    // we capture the lambda of MimeMessagePreparator from the mailSender.send() method since it is
-    // not possible to take Mockito's any() as argument for that method call
-    ArgumentCaptor<MimeMessagePreparator> captor =
-        ArgumentCaptor.forClass(MimeMessagePreparator.class);
-    Mockito.verify(mailSender).send(captor.capture());
-    var mimeMessagePreparator = captor.getValue();
-
-    Mockito.verify(mailSender, Mockito.times(1)).send(mimeMessagePreparator);
   }
 
   @Test

--- a/src/test/java/org/opendevstack/provision/services/StorageAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/StorageAdapterTest.java
@@ -21,11 +21,9 @@ import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.opendevstack.provision.authentication.TestAuthentication;
 import org.opendevstack.provision.model.OpenProjectData;
 import org.opendevstack.provision.storage.LocalStorage;
@@ -34,26 +32,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
 @DirtiesContext
 @ActiveProfiles("utest")
 public class StorageAdapterTest {
 
+  @Autowired private StorageAdapter adapter;
+
   @Mock LocalStorage storage;
 
-  @Autowired private WebApplicationContext context;
-
-  @Autowired StorageAdapter adapter;
-
-  @BeforeEach
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-  }
-
   @Test
-  public void listProjectHistoryNoAuth() throws Exception {
+  public void listProjectHistoryNoAuth() {
     Mockito.when(storage.listProjectHistory()).thenReturn(new HashMap<>());
     adapter.setStorage(storage);
 
@@ -61,7 +51,7 @@ public class StorageAdapterTest {
   }
 
   @Test
-  public void listProjectHistoryWithAuth() throws Exception {
+  public void listProjectHistoryWithAuth() {
     try {
       // open project
       OpenProjectData data = new OpenProjectData();

--- a/src/test/java/org/opendevstack/provision/services/StorageAdapterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/StorageAdapterTest.java
@@ -22,25 +22,22 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opendevstack.provision.authentication.TestAuthentication;
 import org.opendevstack.provision.model.OpenProjectData;
 import org.opendevstack.provision.storage.LocalStorage;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@DirtiesContext
-@ActiveProfiles("utest")
+@ExtendWith(MockitoExtension.class)
 public class StorageAdapterTest {
 
-  @Autowired private StorageAdapter adapter;
+  @InjectMocks private StorageAdapter adapter;
 
-  @Mock LocalStorage storage;
+  @Mock private LocalStorage storage;
 
   @Test
   public void listProjectHistoryNoAuth() {

--- a/src/test/java/org/opendevstack/provision/services/jira/JiraProjectTypePropertyCalculatorTest.java
+++ b/src/test/java/org/opendevstack/provision/services/jira/JiraProjectTypePropertyCalculatorTest.java
@@ -15,9 +15,7 @@ package org.opendevstack.provision.services.jira;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockitoAnnotations;
 import org.opendevstack.provision.services.JiraAdapter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -37,14 +35,8 @@ public class JiraProjectTypePropertyCalculatorTest {
 
   @Autowired private JiraProjectTypePropertyCalculator propertyCalculator;
 
-  @BeforeEach
-  public void beforeTest() {
-    MockitoAnnotations.initMocks(this);
-  }
-
   @Test
   public void givenTemplatePrefixOrDefaultValue_whenOneIsNull_ThenException() {
-
     try {
       propertyCalculator.readPropertyIfTemplateKeyExistsAndIsEnabledOrReturnDefault(
           null, null, "not-null");
@@ -80,18 +72,16 @@ public class JiraProjectTypePropertyCalculatorTest {
 
     // case 1: environment does not contain template prefix + project type and project type is one
     // of the available template key
-    String unknownProjectType = UNKNOWN_PROJECT_TYPE;
     String value =
         propertyCalculator.readPropertyIfTemplateKeyExistsAndIsEnabledOrReturnDefault(
-            unknownProjectType, JiraAdapter.JIRA_TEMPLATE_TYPE_PREFIX, DEFAULT_VALUE);
+            UNKNOWN_PROJECT_TYPE, JiraAdapter.JIRA_TEMPLATE_TYPE_PREFIX, DEFAULT_VALUE);
     assertEquals(DEFAULT_VALUE, value);
 
     // case 2: environment contain template prefix + project type but project type is not one of the
     // available template key
-    String disabledTemplate = DISABLED_TEMPLATE;
     value =
         propertyCalculator.readPropertyIfTemplateKeyExistsAndIsEnabledOrReturnDefault(
-            disabledTemplate, JiraAdapter.JIRA_TEMPLATE_TYPE_PREFIX, DEFAULT_VALUE);
+            DISABLED_TEMPLATE, JiraAdapter.JIRA_TEMPLATE_TYPE_PREFIX, DEFAULT_VALUE);
     assertEquals(DEFAULT_VALUE, value);
   }
 }

--- a/src/test/java/org/opendevstack/provision/services/jira/WebhookProxyJiraPropertyUpdaterTest.java
+++ b/src/test/java/org/opendevstack/provision/services/jira/WebhookProxyJiraPropertyUpdaterTest.java
@@ -21,24 +21,23 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.net.URL;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opendevstack.provision.services.JiraAdapter;
 import org.opendevstack.provision.services.webhookproxy.WebhookProxyUrlFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@ActiveProfiles("utest")
+@ExtendWith(MockitoExtension.class)
 public class WebhookProxyJiraPropertyUpdaterTest {
 
-  @MockBean private JiraProjectPropertyUpdater jiraProjectPropertyUpdater;
+  @InjectMocks private WebhookProxyJiraPropertyUpdater webhookProxyJiraPropertyUpdater;
 
-  @MockBean private JiraAdapter jiraRestService;
+  @Mock private JiraProjectPropertyUpdater jiraProjectPropertyUpdater;
 
-  @MockBean private WebhookProxyUrlFactory webhookProxyUrlFactory;
+  @Mock private JiraAdapter jiraRestService;
 
-  @Autowired private WebhookProxyJiraPropertyUpdater webhookProxyJiraPropertyUpdater;
+  @Mock private WebhookProxyUrlFactory webhookProxyUrlFactory;
 
   @Test
   public void givenAddWebhookProxy_whenEndpointIsNotValidUrl_thenIOException() {

--- a/src/test/java/org/opendevstack/provision/services/openshift/OpenshiftClientTest.java
+++ b/src/test/java/org/opendevstack/provision/services/openshift/OpenshiftClientTest.java
@@ -24,17 +24,18 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 public class OpenshiftClientTest {
 
-  @MockBean private IClient ocClient;
+  @InjectMocks private OpenshiftClient openshiftClient;
+
+  @Mock private IClient ocClient;
 
   private String url = "http://url.com";
-
-  private OpenshiftClient openshiftClient;
 
   @BeforeEach
   public void setup() {
@@ -44,16 +45,16 @@ public class OpenshiftClientTest {
   @Test
   public void testOpenshiftClientReturnsProjectKeys() {
 
-    String projectname = "ods";
+    String projectName = "ods";
     IResource resource = mock(IResource.class);
-    when(resource.getName()).thenReturn(projectname);
+    when(resource.getName()).thenReturn(projectName);
     List.of(resource);
 
     when(ocClient.list("Project")).thenReturn(List.of(resource));
 
     Set<String> projects = openshiftClient.projects();
     assertEquals(1, projects.size());
-    assertTrue(projects.contains(projectname));
+    assertTrue(projects.contains(projectName));
   }
 
   @Test

--- a/src/test/java/org/opendevstack/provision/services/openshift/OpenshiftServiceTest.java
+++ b/src/test/java/org/opendevstack/provision/services/openshift/OpenshiftServiceTest.java
@@ -20,24 +20,21 @@ import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.opendevstack.provision.adapter.exception.AdapterException;
 import org.opendevstack.provision.adapter.exception.CreateProjectPreconditionException;
 import org.opendevstack.provision.controller.CheckPreconditionFailure;
 import org.opendevstack.provision.model.OpenProjectData;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@DirtiesContext
-@ActiveProfiles("utest")
+@ExtendWith(MockitoExtension.class)
 public class OpenshiftServiceTest {
 
-  @MockBean private OpenshiftClient openshiftClient;
+  @InjectMocks private OpenshiftService openshiftService;
 
-  @Autowired private OpenshiftService openshiftService;
+  @Mock private OpenshiftClient openshiftClient;
 
   @BeforeEach
   public void setup() {

--- a/src/test/java/org/opendevstack/provision/util/rest/RestClientTest.java
+++ b/src/test/java/org/opendevstack/provision/util/rest/RestClientTest.java
@@ -23,7 +23,6 @@ import okhttp3.MediaType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opendevstack.provision.util.CredentialsInfo;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -38,7 +37,7 @@ public class RestClientTest {
   @Value("${local.server.port}")
   private int randomServerPort;
 
-  @Autowired private RestClient client;
+  private RestClient client;
 
   @BeforeEach
   public void setUp() {

--- a/src/test/java/org/opendevstack/provision/util/rest/RestClientTest.java
+++ b/src/test/java/org/opendevstack/provision/util/rest/RestClientTest.java
@@ -20,10 +20,8 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.opendevstack.provision.authentication.crowd.CrowdAuthenticationManager;
 import org.opendevstack.provision.util.CredentialsInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -40,9 +38,7 @@ public class RestClientTest {
   @Value("${local.server.port}")
   private int randomServerPort;
 
-  private RestClient client;
-
-  @Autowired CrowdAuthenticationManager manager;
+  @Autowired private RestClient client;
 
   @BeforeEach
   public void setUp() {
@@ -54,7 +50,7 @@ public class RestClientTest {
 
   @Test
   public void getClient() {
-    assertTrue(client.getClient() instanceof OkHttpClient);
+    assertNotNull(client.getClient());
   }
 
   @Test
@@ -80,8 +76,7 @@ public class RestClientTest {
       RestClientCall invalidCall =
           validGetCall().url(String.format("http://localhost:%d", randomServerPort + 1));
       client.execute(invalidCall);
-    } catch (SocketTimeoutException expectedInLocalEnv) {
-    } catch (ConnectException expectedInJenkins) {
+    } catch (SocketTimeoutException | ConnectException ignored) {
     } catch (IOException unexpected) {
       fail(unexpected.getMessage());
     }


### PR DESCRIPTION
relates to #638 

I actually started only out to get rid of the `@InjectMock` in the test but somehow ended up in refactoring more than that:

- removed in a handful of service tests classes the usage of SpringBootTest, DirtiesContext, MockBean and Autowired annotations to only use InjectMocks and Mock because it is way faster and sufficient.
- moved identical code of base- and crowd auth test config into its own auth config class and added `IODSAuthnzAdapter` mock bean and EhCache bean to it
- Replaced manual creation of MockMvc by using @AutoConfigureMockMvc in every class except the ones that require to run without spring security
- applied some Java8+ ways of coding, removed dead/unnecessary code, ...