### PR TITLE
feature: enable a configurable disclaimer in the UI with a new property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Parameterise jira project type templates ([#404](https://github.com/opendevstack/ods-provisioning-app/issues/404))
 - Provision app should support reuse of shared schemes for Jira & not create permission schemes every time ([#151](https://github.com/opendevstack/ods-provisioning-app/issues/151))
 - Add changelog enforcer as GitHub Action to workflow ([#657](https://github.com/opendevstack/ods-provisioning-app/issues/657))
+- Add a configurable ui disclaimer to be set with properties ([#706](https://github.com/opendevstack/ods-provisioning-app/issues/706)) 
 
 ### Fixed
 

--- a/docs/modules/provisioning-app/pages/configuration.adoc
+++ b/docs/modules/provisioning-app/pages/configuration.adoc
@@ -337,7 +337,7 @@ If you need to disable it, you can add this property to the application properti
 services.openshift.enabled=false
 ```
 
-If you need to display a disclaimer you add this property to the application properties:
+If you need to display a disclaimer in the front-end you can add this property to the application properties:
 ```
 provision.ui.disclaimer=<DISCLAIMER_TEXT>
 ```

--- a/docs/modules/provisioning-app/pages/configuration.adoc
+++ b/docs/modules/provisioning-app/pages/configuration.adoc
@@ -337,6 +337,12 @@ If you need to disable it, you can add this property to the application properti
 services.openshift.enabled=false
 ```
 
+If you need to display a disclaimer you add this property to the application properties:
+```
+provision.ui.disclaimer=<DISCLAIMER_TEXT>
+```
+NOTE: this property is not supported yet in the single page front-end.
+
 == FAQ
 
 . Where is the provision app deployed? +

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -148,3 +148,5 @@ jenkinspipeline.adminjobs.delete-components.desc=Delete openshift components
 jenkinspipeline.adminjobs.delete-components.repo=ods-core
 
 springfox.documentation.enabled=false
+
+provision.ui.disclaimer=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -149,4 +149,5 @@ jenkinspipeline.adminjobs.delete-components.repo=ods-core
 
 springfox.documentation.enabled=false
 
+# Configurable UI disclaimer (not supported in single page end)
 provision.ui.disclaimer=

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -7,6 +7,13 @@
         <link rel="stylesheet" th:href="@{/webjars/font-awesome/css/font-awesome.min.css}"/>
         <!--<link rel="stylesheet" th:href="@{/css/main.css}"-->
         <!--href="../../css/main.css" />-->
+        <style>
+            .disclaimer-banner a {
+                color: white;
+                font-weight: bold;
+                text-decoration: underline;
+            }
+        </style>
     </div>
 </head>
 <body>
@@ -28,6 +35,10 @@
             </div>
         </div>
     </nav>
+    <div th:if="${@environment.getProperty('provision.ui.disclaimer') != null && @environment.getProperty('provision.ui.disclaimer') != ''}" class="navbar navbar-dark bg-primary text-light">
+        <div class="mx-auto disclaimer-banner" th:utext="${@environment.getProperty('provision.ui.disclaimer')}">
+        </div>
+    </div>
 </div>
 
 </body>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -8,6 +8,11 @@
         <!--<link rel="stylesheet" th:href="@{/css/main.css}"-->
         <!--href="../../css/main.css" />-->
         <style>
+            .disclaimer-banner {
+                display: flex;
+                justify-content: center;
+                align-items: center;
+            }
             .disclaimer-banner a {
                 color: white;
                 font-weight: bold;
@@ -35,8 +40,8 @@
             </div>
         </div>
     </nav>
-    <div th:if="${@environment.getProperty('provision.ui.disclaimer') != null && @environment.getProperty('provision.ui.disclaimer') != ''}" class="navbar navbar-dark bg-primary text-light">
-        <div class="mx-auto disclaimer-banner" th:utext="${@environment.getProperty('provision.ui.disclaimer')}">
+    <div th:if="${@environment.getProperty('provision.ui.disclaimer') != null && @environment.getProperty('provision.ui.disclaimer') != ''}" class="navbar navbar-dark bg-primary text-light disclaimer-banner">
+        <div class="text-center" th:utext="${@environment.getProperty('provision.ui.disclaimer')}">
         </div>
     </div>
 </div>


### PR DESCRIPTION
Resolves #706 
Added a property to define the disclaimer text. And a text in the header component to be displayed in all the screens in case it is defined.