### PR TITLE
add missing bitbucket repository description on repository creation event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Logging in debug level shows too much jwt details ([#486](https://github.com/opendevstack/ods-provisioning-app/issues/486))
 - DELETE_COMPONENTS API stores and returns project with deleted quickstarter([#702](https://github.com/opendevstack/ods-provisioning-app/issues/702))
 - API DELETE*: wrong jenkins run job (lastExecutionJobs) returned ([#790](https://github.com/opendevstack/ods-provisioning-app/issues/790))
+- Add missing bitbucket repository description on repository creation event ([#712](https://github.com/opendevstack/ods-provisioning-app/issues/712))
 
 ## [3.0] - 2020-08-11
 

--- a/src/main/java/org/opendevstack/provision/model/bitbucket/Repository.java
+++ b/src/main/java/org/opendevstack/provision/model/bitbucket/Repository.java
@@ -25,6 +25,7 @@ public class Repository {
   private String name;
   private String scmId = "git";
   private boolean forkable = true;
+  private String description;
 
   @JsonIgnoreProperties({"adminGroup", "userGroup"})
   private String adminGroup;
@@ -69,6 +70,14 @@ public class Repository {
 
   public String getUserGroup() {
     return this.userGroup;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getDescription() {
+    return this.description;
   }
 
   @Override

--- a/src/main/java/org/opendevstack/provision/services/BitbucketAdapter.java
+++ b/src/main/java/org/opendevstack/provision/services/BitbucketAdapter.java
@@ -468,6 +468,11 @@ public class BitbucketAdapter extends BaseServiceAdapter implements ISCMAdapter 
         Repository repo = new Repository();
         repo.setName(repoName);
 
+        String repoDescription = option.get(OpenProjectData.COMPONENT_DESC_KEY);
+        if (repoDescription != null) {
+          repo.setDescription(repoDescription);
+        }
+
         if (project.isSpecialPermissionSet()) {
           repo.setAdminGroup(project.getProjectAdminGroup());
           repo.setUserGroup(project.getProjectUserGroup());
@@ -523,6 +528,7 @@ public class BitbucketAdapter extends BaseServiceAdapter implements ISCMAdapter 
       Repository repo = new Repository();
       String repoName = createRepoNameFromComponentName(project.getProjectKey(), name);
       repo.setName(repoName);
+      repo.setDescription("ODS generated repo: " + name);
 
       if (project.isSpecialPermissionSet()) {
         repo.setAdminGroup(project.getProjectAdminGroup());


### PR DESCRIPTION
I never understood why we did not seed the component description into the repo ... (as it's possible) .. but here it finally is...