### PR TITLE
Backport: Fix problem assigning admin permissions to bitbucket repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
 ## Unreleased
-- Fix problem assigning admin permissions to bitbucket repositories ([#700](https://github.com/opendevstack/ods-provisioning-app/pull/700))
 
 ### Fixed
 - DELETE_COMPONENTS API stores and returns project with deleted quickstarter([#702](https://github.com/opendevstack/ods-provisioning-app/issues/702))
 - Add a configurable ui disclaimer to be set with properties ([#706](https://github.com/opendevstack/ods-provisioning-app/issues/706))
 - API DELETE*: wrong jenkins run job (lastExecutionJobs) returned ([#710](https://github.com/opendevstack/ods-provisioning-app/issues/710))
 - Missing bitbucket repository description on repository creation event ([#713](https://github.com/opendevstack/ods-provisioning-app/issues/713))
+- Fix problem assigning admin permissions to bitbucket repositories ([#700](https://github.com/opendevstack/ods-provisioning-app/pull/700))
 
 ## [4.0] - 2021-11-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix problem assigning admin permissions to bitbucket repositories ([#700](https://github.com/opendevstack/ods-provisioning-app/pull/700))
 
 ### Fixed
 - DELETE_COMPONENTS API stores and returns project with deleted quickstarter([#702](https://github.com/opendevstack/ods-provisioning-app/issues/702))

--- a/docs/modules/provisioning-app/pages/configuration.adoc
+++ b/docs/modules/provisioning-app/pages/configuration.adoc
@@ -50,11 +50,13 @@ However there is a special knob to tighten security (which can be passed with th
 . user group: read / write rights on the generated projects / spaces / repositories
 . readonly group: read rights on the generated projects / spaces / repositories
 
+Moreover, a specific CD user (technical user for the continuous delivery platform) can optionally be specified.
+
 The configuration for the permission sets are configured:
 
 . JIRA Project is provisioned with its own permissionset defined in https://github.com/opendevstack/ods-provisioning-app/blob/master/src/main/resources/permission-templates/jira.permission.all.txt[src/main/resources/permission-templates/jira.permission.all.txt]
 . Confluence Project is provisioned with special permission set defined in https://github.com/opendevstack/ods-provisioning-app/blob/master/src/main/resources/permission-templates[src/main/resources/permission-templates/confluence.permission.*]
-. Bitbucket Project is provisioned with tight read & write roles
+. Bitbucket Project is provisioned with the permissions detailed in the section <<Bitbucket permissions>>.
 . Openshift Project roles linked to the passed groups (`READONLY` - `view`, `ADMINGROUP` - `admin`, `USERS` - `edit`)
 
 Furthermore if you need to define default permission for openshift (e.g. to setup membership permission for cluster admins) you can add this to your application properties:
@@ -62,7 +64,87 @@ Furthermore if you need to define default permission for openshift (e.g. to setu
 jenkinspipeline.create-project.default-project-groups=ADMINGROUP=<MY_CLUSTER_ADMIN_GROUP_NAME>
 ```
 
-In case special permissions sets are defined this the default project groups will be appended to the lis of permissions sets.
+In case special permissions sets are defined this the default project groups will be appended to the list of permissions sets.
+
+=== Bitbucket permissions
+Permissions are set both at project and repository levels.
+
+Whenever the same user or group is assigned different permissions in the same project or repository,
+the actual permissions assigned are the higher-level ones.
+
+For example, if a group is assigned read-only and R/W permissions in the same project,
+it will get R/W permissions on it. If a user is assigned both R/W and admin permissions in a repository,
+it will get admin permissions on it.
+
+The mentioned properties in the following subsections have default values specified in the `application.properties` file.
+Their values can be overridden in the corresponding config map.
+
+==== Project level
+Permissions set at project level depend on whether the special permission set has been specified or not.
+
+If the special permission set has been specified, these are the permissions set at project level:
+
+|===
+|Type |Who? |Permission
+
+|Group|`${global.keyuser.role.name}`|Admin
+|Group|admin group|Admin
+|Group|user group|R/W
+|Group|readonly group|Read only
+|User|CD user (Default:  `${bitbucket.technical.user}`)|R/W
+|===
+
+Additionally, whenever a specific CD User is specified on project creation,
+this user gets read permissions in all repositories specified as readable repos
+(such as link:https://github.com/opendevstack/ods-jenkins-shared-library[ods-jenkins-shared-library]
+and link:https://github.com/opendevstack/ods-quickstarters[ods-quickstarters]).
+
+Note that, if a specific CD user has not been specified,
+it defaults to the value of the `bitbucket.technical.user` property.
+
+If the special permission set has not been specified, these are the default permissions assigned to the project:
+
+|===
+|Type |Who? |Permission
+
+|Group|`${bitbucket.default.user.group}`|R/W
+|Group|`${idmanager.group.opendevstack-users}`|Read only
+|User|CD user (Default:  `${bitbucket.technical.user}`)|R/W
+|===
+
+Additionally, whenever a specific CD User is specified on project creation,
+this user gets read permissions in all repositories specified as readable repos
+(such as link:https://github.com/opendevstack/ods-jenkins-shared-library[ods-jenkins-shared-library]
+and link:https://github.com/opendevstack/ods-quickstarters[ods-quickstarters]).
+
+Note that no admin permissions are assigned to the project when a special permission set has not been specified.
+The only project-level administrators are the global Bitbucket administrators, in this case.
+
+==== Repository level
+Repositories belonging to a project inherit the project permissions.
+Some additional permissions are assigned at repository level.
+
+The following tables show the permissions specified at repository level.
+
+These are the permissions assigned to the repository when a special permission set has been specified:
+
+|===
+|Type |Who? |Permission
+
+|User|`${bitbucket.technical.user}`|R/W
+|===
+
+These are the permissions assigned to the repository when a special permission set has not been specified:
+
+|===
+|Type |Who? |Permission
+
+|Group|`${bitbucket.default.admin.group}` (default: `${bitbucket.default.user.group}`)|Admin
+|User|`${bitbucket.technical.user}`|R/W
+|===
+
+If the `bitbucket.default.admin.group` property is specified with an empty value,
+no admin permissions are assigned at repository level.
 
 == Project/Space types based on templates
 

--- a/docs/modules/provisioning-app/pages/index.adoc
+++ b/docs/modules/provisioning-app/pages/index.adoc
@@ -27,3 +27,6 @@ After provisioning the quickstarter, you’ll have a new repository in your Bitb
 The `<project-key>-dev` and `<project-key>-test` namespaces are **runtime** namespaces. Depending on which branch you merge / commit your code into, images will be built & deployed in one of the two (further information on how this is done - can be found in the xref:jenkins-shared-library:component-pipeline.adoc[Component Pipeline] +
 In contrast to this, the `<project-key>-cd` namespace hosts a project-specific instance of xref:jenkins:master.adoc[Jenkins Master] and xref:jenkins:webhook-proxy.adoc[Webhook Proxy]. When a build is triggered, builder pods (= deployments of xref:jenkins:slave-base.adoc[Jenkins slaves]) are created in this project. +
 This was a cautious design choice to give a project team as much power as possible when it comes to configuration of Jenkins.
+. What permissions are assigned when a new Bitbucket project or repository is created? +
+The assigned permissions are detailed xref:configuration.adoc#_bitbucket_permissions[here].
+

--- a/src/main/java/org/opendevstack/provision/services/BitbucketAdapter.java
+++ b/src/main/java/org/opendevstack/provision/services/BitbucketAdapter.java
@@ -86,6 +86,9 @@ public class BitbucketAdapter extends BaseServiceAdapter implements ISCMAdapter 
   @Value("${bitbucket.default.user.group}")
   private String defaultUserGroup;
 
+  @Value("${bitbucket.default.admin.group}")
+  private String defaultAdminGroup;
+
   @Value("${bitbucket.technical.user}")
   private String technicalUser;
 
@@ -94,9 +97,6 @@ public class BitbucketAdapter extends BaseServiceAdapter implements ISCMAdapter 
 
   @Value("${idmanager.group.opendevstack-users}")
   private String openDevStackUsersGroupName;
-
-  @Value("${provision.scm.grant.repository.writetoeveryuser:false}")
-  private boolean grantRepositoryWriteToAllOpenDevStackUsers;
 
   @Value("${openshift.jenkins.project.webhookproxy.events}")
   private List<String> webhookEvents;
@@ -477,14 +477,15 @@ public class BitbucketAdapter extends BaseServiceAdapter implements ISCMAdapter 
           repo.setAdminGroup(project.getProjectAdminGroup());
           repo.setUserGroup(project.getProjectUserGroup());
         } else {
-          repo.setAdminGroup(defaultUserGroup);
+          repo.setAdminGroup(defaultAdminGroup);
           repo.setUserGroup(defaultUserGroup);
         }
 
         Map<URL_TYPE, String> componentRepository = null;
 
         try {
-          RepositoryData result = callCreateRepoApi(project.getProjectKey(), repo);
+          RepositoryData result =
+              callCreateRepoApi(project.getProjectKey(), project.isSpecialPermissionSet(), repo);
           createWebHooksForRepository(
               result, project, option.get(OpenProjectData.COMPONENT_TYPE_KEY));
 
@@ -534,12 +535,13 @@ public class BitbucketAdapter extends BaseServiceAdapter implements ISCMAdapter 
         repo.setAdminGroup(project.getProjectAdminGroup());
         repo.setUserGroup(project.getProjectUserGroup());
       } else {
-        repo.setAdminGroup(globalKeyuserRoleName);
+        repo.setAdminGroup(defaultAdminGroup);
         repo.setUserGroup(defaultUserGroup);
       }
 
       try {
-        RepositoryData result = callCreateRepoApi(project.getProjectKey(), repo);
+        RepositoryData result =
+            callCreateRepoApi(project.getProjectKey(), project.isSpecialPermissionSet(), repo);
         repositories.put(result.getName(), result.convertRepoToOpenDataProjectRepo());
       } catch (IOException ex) {
         logger.error("Error in creating auxiliary repo", ex);
@@ -597,24 +599,24 @@ public class BitbucketAdapter extends BaseServiceAdapter implements ISCMAdapter 
     BitbucketProjectData projectData = getRestClient().execute(call);
     if (project.isSpecialPermissionSet()) {
       setProjectPermissions(
+          projectData,
+          ID_GROUPS,
+          project.getProjectReadonlyGroup(),
+          PROJECT_PERMISSIONS.PROJECT_READ);
+      setProjectPermissions(
+          projectData, ID_GROUPS, project.getProjectUserGroup(), PROJECT_PERMISSIONS.PROJECT_WRITE);
+      setProjectPermissions(
           projectData, ID_GROUPS, globalKeyuserRoleName, PROJECT_PERMISSIONS.PROJECT_ADMIN);
       setProjectPermissions(
           projectData,
           ID_GROUPS,
           project.getProjectAdminGroup(),
           PROJECT_PERMISSIONS.PROJECT_ADMIN);
-      setProjectPermissions(
-          projectData, ID_GROUPS, project.getProjectUserGroup(), PROJECT_PERMISSIONS.PROJECT_WRITE);
-      setProjectPermissions(
-          projectData,
-          ID_GROUPS,
-          project.getProjectReadonlyGroup(),
-          PROJECT_PERMISSIONS.PROJECT_READ);
     } else {
       setProjectPermissions(
-          projectData, ID_GROUPS, defaultUserGroup, PROJECT_PERMISSIONS.PROJECT_WRITE);
-      setProjectPermissions(
           projectData, ID_GROUPS, openDevStackUsersGroupName, PROJECT_PERMISSIONS.PROJECT_READ);
+      setProjectPermissions(
+          projectData, ID_GROUPS, defaultUserGroup, PROJECT_PERMISSIONS.PROJECT_WRITE);
     }
 
     String projectCdUser = technicalUser;
@@ -651,8 +653,8 @@ public class BitbucketAdapter extends BaseServiceAdapter implements ISCMAdapter 
     return projectData;
   }
 
-  protected RepositoryData callCreateRepoApi(String projectKey, Repository repo)
-      throws IOException {
+  protected RepositoryData callCreateRepoApi(
+      String projectKey, boolean isSpecialPermissionSet, Repository repo) throws IOException {
     String path = String.format("%s/%s/repos", getAdapterApiUri(), projectKey);
 
     RepositoryData data =
@@ -664,20 +666,13 @@ public class BitbucketAdapter extends BaseServiceAdapter implements ISCMAdapter 
                   + " - no response from endpoint, please check logs",
               repo.getName(), projectKey));
     }
-    setRepositoryAdminPermissions(data, projectKey, ID_GROUPS, repo.getUserGroup());
-    setRepositoryWritePermissions(data, projectKey, ID_USERS, technicalUser);
-    if (grantRepositoryWriteToAllOpenDevStackUsers) {
-      logger.info(
-          "Grant write to every member of {} to repository {}",
-          openDevStackUsersGroupName,
-          data.getSlug());
-      setRepositoryPermissions(
-          data.getSlug(),
-          projectKey,
-          ID_GROUPS,
-          openDevStackUsersGroupName,
-          REPOSITORY_PERMISSIONS.REPO_WRITE);
+    if (!isSpecialPermissionSet) {
+      String adminGroup = repo.getAdminGroup();
+      if (adminGroup != null && !adminGroup.isEmpty()) {
+        setRepositoryAdminPermissions(data, projectKey, ID_GROUPS, adminGroup);
+      }
     }
+    setRepositoryWritePermissions(data, projectKey, ID_USERS, technicalUser);
     return data;
   }
 

--- a/src/main/resources/application-odsbox.properties
+++ b/src/main/resources/application-odsbox.properties
@@ -10,6 +10,7 @@ adapters.confluence.enabled=false
 
 # Bitbucket properties
 bitbucket.uri=http://bitbucket.odsbox.lan:7990
+bitbucket.default.admin.group=${bitbucket.default.user.group}
 bitbucket.default.user.group=bitbucket-users
 bitbucket.technical.user=openshift
 bitbucket.opendevstack.project=opendevstack

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -69,6 +69,7 @@ bitbucket.uri=http://192.168.56.31:7990
 #bitbucket.admin_password=admin
 bitbucket.api.path=/rest/api/1.0
 bitbucket.repository.pattern=%s-%s
+bitbucket.default.admin.group=${bitbucket.default.user.group}
 bitbucket.default.user.group=opendevstack-administrators
 bitbucket.technical.user=cd_user
 bitbucket.opendevstack.project=opendevstack

--- a/src/test/resources/application-utest.properties
+++ b/src/test/resources/application-utest.properties
@@ -23,6 +23,9 @@ global.keyuser.role.name=${idmanager.group.opendevstack-administrators}
 
 adapters.check-preconditions.timeout-in-seconds=30
 
+#Bitbucket properties
+bitbucket.default.admin.group=${idmanager.group.opendevstack-administrators}
+bitbucket.default.user.group=${idmanager.group.opendevstack-users}
 
 # aouth2 client configuration
 idmanager.realm=testrealm


### PR DESCRIPTION
fixes #700 port to 4.x

* Only set admin permissions at repo level, if special permission set was not specified on project creation.

* Assign admin permissions to the default admin group when a specific one
wasn not specified

* The admin group defaults to the user group in the application.properties
file.

Co-authored-by: zxBCN Farre_Basurte,Juan_Antonio (IT EDS) EXTERNAL <juan_antonio.farre_basurte.ext@boehringer-ingelheim.com>