### PR TITLE
Fix CVE-2021-4104 and change base image to Eclipse Temurin 11 JRE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Fixed
+- Fix CVE-2021-4104 and change java base image ([#761](https://github.com/opendevstack/ods-provisioning-app/pull/761))
 
 ## [4.3.0] - 2025-03-25
 

--- a/build.gradle
+++ b/build.gradle
@@ -130,15 +130,20 @@ dependencies {
             strictly '3.5.2'
         } // Cannot upgrade to '3.5.24'
         transitive = true
+        exclude group: 'log4j', module: 'log4j'
     }
     implementation('com.atlassian.security:atlassian-security:3.2.14') {
         transitive = true
+        exclude group: 'log4j', module: 'log4j'
     }
     implementation('com.atlassian.security:atlassian-cookie-tools:3.2.14') {
         transitive = true
+        exclude group: 'log4j', module: 'log4j'
     }
     implementation('javax.validation:validation-api:2.0.1.Final')
-    implementation('com.atlassian.crowd:crowd-integration-springsecurity:5.1.3')
+    implementation('com.atlassian.crowd:crowd-integration-springsecurity:5.1.3') {
+        exclude group: 'log4j', module: 'log4j'
+    }
     implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
     implementation group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '2.3.1'
     implementation group: 'xerces', name: 'xercesImpl', version: '2.9.1'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM adoptopenjdk/openjdk11:ubi-jre
+FROM docker.io/library/eclipse-temurin:11-jre-ubi9-minimal
+
+RUN microdnf update -y && microdnf clean all
  
 COPY files/entrypoint.sh /usr/local/bin/
 COPY app.jar app.jar


### PR DESCRIPTION
- Fixed CVE-2021-4104 by excluding log4j in atlassian packages
- Updated base image to Eclipse Temurin 11 JRE and added microdnf update.